### PR TITLE
Fix sync workflow permissions

### DIFF
--- a/.github/workflows/sync-shared-files.yml
+++ b/.github/workflows/sync-shared-files.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: "0 0,6,12,18 * * *"
 
+permissions:
+  contents: write
+
 jobs:
   sync-agents-md:
     uses: jdfalk/ghcommon/.github/workflows/reusable-sync-shared-files.yml@main


### PR DESCRIPTION
## Description
Add missing permissions to the sync workflow so push succeeds.

## Motivation
The sync shared-files jobs failed because the workflow lacked write access for `GITHUB_TOKEN`. Granting `contents: write` resolves git push errors.

## Changes
- add `permissions` block to workflow

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685f54238a8c832195cd2babe992063a