### PR TITLE
Add docs update workflow

### DIFF
--- a/.github/issue-updates/0fa3f7a8-8ff3-41ba-ae45-c83cb0dc7e23.json
+++ b/.github/issue-updates/0fa3f7a8-8ff3-41ba-ae45-c83cb0dc7e23.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Centralize docs update",
+  "body": "Implement reusable workflow for README, CHANGELOG, and TODO updates.",
+  "labels": ["codex", "documentation"],
+  "guid": "0fa3f7a8-8ff3-41ba-ae45-c83cb0dc7e23",
+  "legacy_guid": "create-centralize-docs-update-2025-07-09"
+}

--- a/.github/workflows/reusable-docs-update.yml
+++ b/.github/workflows/reusable-docs-update.yml
@@ -1,0 +1,44 @@
+# file: .github/workflows/reusable-docs-update.yml
+# version: 1.0.0
+# guid: 25b987e1-9e34-4618-8182-53e12c7307e0
+
+name: Reusable Docs Update
+
+on:
+  workflow_call:
+    inputs:
+      updates-directory:
+        description: "Directory with doc updates"
+        required: false
+        default: ".github/doc-updates"
+        type: string
+
+jobs:
+  docs-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Apply documentation updates
+        run: |
+          python scripts/doc_update_manager.py "${{ inputs.updates-directory }}"
+
+      - name: Commit changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name 'github-actions'
+            git config user.email 'github-actions@users.noreply.github.com'
+            git add -A
+            git commit -m 'docs: apply documentation updates'
+            git push
+          else
+            echo 'No documentation changes to commit'
+          fi

--- a/docs/documentation-updates.md
+++ b/docs/documentation-updates.md
@@ -1,0 +1,22 @@
+<!-- file: docs/documentation-updates.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b1d1f0f3-9c8a-4c9b-8cc6-b0fc9c573c10 -->
+
+# Documentation Updates Workflow
+
+A centralized workflow for updating `README.md`, `CHANGELOG.md` and `TODO.md`.
+Jobs create JSON files in `.github/doc-updates/` with the helper script and the
+workflow applies them to reduce merge conflicts.
+
+## Usage
+
+1. Generate an update file:
+
+```bash
+./scripts/create-doc-update.sh README.md "Add new section" 
+```
+
+2. Commit the generated JSON file.
+3. Trigger the `reusable-docs-update.yml` workflow.
+
+Processed files are moved to `.github/doc-updates/processed/`.

--- a/scripts/create-doc-update.sh
+++ b/scripts/create-doc-update.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# file: scripts/create-doc-update.sh
+# version: 1.0.0
+# guid: 4db28a8c-33e2-4853-9f0c-1d8283720bd1
+
+set -euo pipefail
+
+print_usage() {
+  echo "Usage: $0 FILE CONTENT [MODE]" >&2
+  echo "MODE defaults to 'append'" >&2
+}
+
+generate_uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    python3 -c 'import uuid; print(uuid.uuid4())'
+  fi
+}
+
+create_update() {
+  local file="$1"
+  local content="$2"
+  local mode="${3:-append}"
+  local uuid="$(generate_uuid)"
+  local dir=".github/doc-updates"
+  mkdir -p "$dir"
+  local path="$dir/${uuid}.json"
+  jq -n --arg file "$file" --arg mode "$mode" --arg content "$content" \
+    --arg guid "$uuid" '{file:$file, mode:$mode, content:$content, guid:$guid}' \
+    > "$path"
+  echo "Created doc update: $path"
+}
+
+if [[ $# -lt 2 ]]; then
+  print_usage
+  exit 1
+fi
+
+create_update "$1" "$2" "${3:-append}"

--- a/scripts/doc_update_manager.py
+++ b/scripts/doc_update_manager.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# file: scripts/doc_update_manager.py
+# version: 1.0.0
+# guid: 9e1fdb20-7abd-4b66-b5b5-95180715d24c
+"""Apply documentation updates from JSON files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+def apply_update(update: dict[str, str]) -> None:
+    path = Path(update["file"])
+    mode = update.get("mode", "append")
+    content = update.get("content", "")
+
+    if mode == "append":
+        text = path.read_text(encoding="utf-8") if path.exists() else ""
+        with path.open("w", encoding="utf-8") as fh:
+            fh.write(text.rstrip() + "\n" + content + "\n")
+    elif mode == "replace":
+        with path.open("w", encoding="utf-8") as fh:
+            fh.write(content + "\n")
+
+
+def process(directory: str) -> list[Path]:
+    updates_dir = Path(directory)
+    processed: list[Path] = []
+
+    for file in sorted(updates_dir.glob("*.json")):
+        with file.open(encoding="utf-8") as fh:
+            update = json.load(fh)
+        apply_update(update)
+        processed.append(file)
+    if processed:
+        processed_dir = updates_dir / "processed"
+        processed_dir.mkdir(exist_ok=True)
+        for file in processed:
+            file.rename(processed_dir / file.name)
+    return processed
+
+
+def main(argv: list[str]) -> None:
+    directory = argv[1] if len(argv) > 1 else ".github/doc-updates"
+    files = process(directory)
+    if files:
+        print(f"Processed {len(files)} documentation updates")
+        for file in files:
+            print(f"- {file.name}")
+    else:
+        print("No documentation updates found")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Description
Format reusable docs update workflow and create issue update to track the feature.

## Motivation
Keeps workflow syntax consistent and logs the need for centralized documentation updates.

## Changes
- Format `.github/workflows/reusable-docs-update.yml`
- Add `.github/issue-updates/0fa3f7a8-8ff3-41ba-ae45-c83cb0dc7e23.json`

## Testing
- `python scripts/doc_update_manager.py`
- `./scripts/create-issue-update.sh create "Centralize docs update" "Implement reusable workflow for README, CHANGELOG, and TODO updates." "codex,documentation"`


------
https://chatgpt.com/codex/tasks/task_e_686bcd130dac8321bb8efe907c9326d9