### PR TITLE
Add reusable add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+# file: .github/workflows/add-to-project.yml
+# version: 1.0.0
+# guid: 52e15436-73cb-4363-8747-94b019db7626
+
+name: Add To Project
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled]
+  pull_request:
+    types: [opened, reopened, labeled]
+
+jobs:
+  add-to-project:
+    uses: ./.github/workflows/reusable-add-to-project.yml
+    with:
+      project-url: https://github.com/orgs/<org>/projects/<number>
+    secrets: inherit

--- a/.github/workflows/reusable-add-to-project.yml
+++ b/.github/workflows/reusable-add-to-project.yml
@@ -1,0 +1,39 @@
+# file: .github/workflows/reusable-add-to-project.yml
+# version: 1.0.0
+# guid: b607c139-2e4c-482a-908e-b96d228b1ee7
+
+name: Reusable - Add To Project
+
+on:
+  workflow_call:
+    inputs:
+      project-url:
+        description: "URL of the GitHub project"
+        required: true
+        type: string
+      labeled:
+        description: "Comma-separated labels to match"
+        required: false
+        default: ""
+        type: string
+      label-operator:
+        description: "Label filter behavior (AND, OR, NOT)"
+        required: false
+        default: "OR"
+        type: string
+    secrets:
+      github-token:
+        description: "PAT with project write access"
+        required: true
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: ${{ inputs.project-url }}
+          labeled: ${{ inputs.labeled }}
+          label-operator: ${{ inputs.label-operator }}
+          github-token: ${{ secrets.github-token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive security guidelines
 - Copilot instructions for AI-assisted development
 - GitHub issue and PR templates
+- **Add To Project Workflow**: Reusable automation to add issues and pull requests to GitHub Projects
 
 ### Changed
 
@@ -62,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/labeler.yml`: Comprehensive labeler configuration with 15+ label categories
 - `.github/workflows/example-usage.yml`: Example demonstrating both CI and labeler workflows
 - `docs/dependency-submission-and-labeling.md`: Complete documentation for new features
+- `.github/workflows/reusable-add-to-project.yml`: Reusable workflow for adding items to projects
+- `.github/workflows/add-to-project.yml`: Workflow using the reusable version
+- `examples/workflows/add-to-project.yml`: Example workflow for other repositories
 
 ### Security
 

--- a/docs/add-to-project.md
+++ b/docs/add-to-project.md
@@ -1,0 +1,54 @@
+<!-- file: docs/add-to-project.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: de8c16e6-d74c-4914-9a04-666d8b4fb2db -->
+
+# Add To Project Workflow
+
+A reusable GitHub Actions workflow for automatically adding issues and pull requests to GitHub Projects.
+
+## Workflow Architecture
+
+- **Canonical Workflow**: `jdfalk/ghcommon/.github/workflows/reusable-add-to-project.yml@main`
+- **Documentation**: This file (`docs/add-to-project.md`)
+- **Example**: `/examples/workflows/add-to-project.yml`
+
+## Quick Start
+
+1. Copy the example workflow to your repository:
+
+```bash
+curl -o .github/workflows/add-to-project.yml \
+  https://raw.githubusercontent.com/jdfalk/ghcommon/main/examples/workflows/add-to-project.yml
+```
+
+2. Update `project-url` with the URL of your GitHub Project.
+
+## Example Workflow
+
+```yaml
+name: Add Issues to Project
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled]
+  pull_request:
+    types: [opened, reopened, labeled]
+
+jobs:
+  add-to-project:
+    uses: jdfalk/ghcommon/.github/workflows/reusable-add-to-project.yml@main
+    with:
+      project-url: https://github.com/orgs/<org>/projects/<number>
+    secrets:
+      github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+```
+
+## Inputs
+
+- `project-url` (**required**) - URL of the GitHub project
+- `labeled` (optional) - Comma-separated list of labels to match
+- `label-operator` (optional) - Label filter behavior (`AND`, `OR`, `NOT`)
+
+## Secrets
+
+- `github-token` - Personal access token with project write access

--- a/examples/workflows/add-to-project.yml
+++ b/examples/workflows/add-to-project.yml
@@ -1,0 +1,19 @@
+# file: examples/workflows/add-to-project.yml
+# version: 1.0.0
+# guid: 8bc1d36c-a8b3-4387-8e85-f45214b5dda4
+
+name: Add To Project Example
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled]
+  pull_request:
+    types: [opened, reopened, labeled]
+
+jobs:
+  add-to-project:
+    uses: jdfalk/ghcommon/.github/workflows/reusable-add-to-project.yml@main
+    with:
+      project-url: https://github.com/orgs/<org>/projects/<number>
+    secrets:
+      github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Description
Add reusable workflow for automatically adding issues or pull requests to GitHub Projects and integrate it in this repository.

## Motivation
Centralizes project automation so all repositories can easily add items to projects.

## Changes
- New reusable workflow `reusable-add-to-project.yml`
- Repository workflow `add-to-project.yml` using the reusable version
- Example workflow for external repos
- Documentation for the new workflow
- Changelog entries

## Testing
- `bash .github/validate-setup.sh`
- `python3 -m pytest -q` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_686e93f6a0608321aa93fe8e89df37d1