### PR TITLE
Add GitHub Projects automation script

### DIFF
--- a/.github/doc-updates/48a262f6-c254-4a3c-aa58-e9915fa5fce8.json
+++ b/.github/doc-updates/48a262f6-c254-4a3c-aa58-e9915fa5fce8.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "- **Project Automation**: Script to create GitHub Projects via CLI",
+  "guid": "48a262f6-c254-4a3c-aa58-e9915fa5fce8",
+  "created_at": "2025-07-09T19:07:20Z",
+  "options": {
+    "section": null,
+    "after": "- **Setup Scripts**: Automated repository configuration",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/e0cecd9e-1436-4387-af84-6d9978a394a6.json
+++ b/.github/doc-updates/e0cecd9e-1436-4387-af84-6d9978a394a6.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Finalize GitHub Projects automation",
+  "guid": "e0cecd9e-1436-4387-af84-6d9978a394a6",
+  "created_at": "2025-07-09T19:07:04Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": "MED",
+    "category": null
+  }
+}

--- a/.github/doc-updates/e4a9e431-604e-4292-b72c-4e2be268fbc1.json
+++ b/.github/doc-updates/e4a9e431-604e-4292-b72c-4e2be268fbc1.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added GitHub Projects automation script",
+  "guid": "e4a9e431-604e-4292-b72c-4e2be268fbc1",
+  "created_at": "2025-07-09T19:07:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/scripts/create-projects.sh
+++ b/scripts/create-projects.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# file: scripts/create-projects.sh
+# version: 1.0.0
+# guid: f4797552-6742-490f-96f4-3d3f6436630a
+
+set -euo pipefail
+
+# Script to create GitHub Projects using the GitHub CLI.
+# Requires GH_TOKEN with 'project' scope or authenticated gh CLI.
+
+ORG="${ORG:-jdfalk}"
+REPO="${REPO:-ghcommon}"
+
+create_project() {
+  local title="$1"
+  local body="$2"
+  echo "Creating project: $title"
+  gh project create --owner "$ORG" --title "$title" --body "$body"
+}
+
+# Example projects based on TODO phases
+create_project "ghcommon Cleanup" "Tasks for initial infrastructure cleanup and documentation fixes."
+create_project "ghcommon Core Improvements" "Track enhancements and error handling for issue management and workflows."
+create_project "ghcommon Testing & Quality" "Work to add unit tests and workflow validation." 
+
+# Link repository to first project (Cleanup)
+FIRST_PROJECT_NUMBER=$(gh project list --owner "$ORG" --limit 1 --format json | jq -r '.[0].number')
+if [[ -n "$FIRST_PROJECT_NUMBER" ]]; then
+  gh project link --owner "$ORG" --repo "$REPO" "$FIRST_PROJECT_NUMBER"
+fi


### PR DESCRIPTION
## Summary
- add `create-projects.sh` for creating GitHub Projects via CLI
- document new script through doc updates
- append TODO task for project automation
- changelog entry for the new script

## Testing
- `bash .github/validate-setup.sh`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'inquirer')*

------
https://chatgpt.com/codex/tasks/task_e_686ebc3288888321b6b059364603d6ed