### PR TITLE
Add stale issue workflows

### DIFF
--- a/.github/doc-updates/4cf31955-2ea0-4781-a0a6-a1119b6a4812.json
+++ b/.github/doc-updates/4cf31955-2ea0-4781-a0a6-a1119b6a4812.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added reusable stale issue handler",
+  "guid": "4cf31955-2ea0-4781-a0a6-a1119b6a4812",
+  "created_at": "2025-07-10T16:27:48Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/5f5c45b5-4c04-431b-b4c9-f68325930a17.json
+++ b/.github/doc-updates/5f5c45b5-4c04-431b-b4c9-f68325930a17.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Document usage for stale workflow",
+  "guid": "5f5c45b5-4c04-431b-b4c9-f68325930a17",
+  "created_at": "2025-07-10T16:27:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9b08cc14-42a9-4864-976d-caf00469f6cd.json
+++ b/.github/doc-updates/9b08cc14-42a9-4864-976d-caf00469f6cd.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Added stale issue management workflow",
+  "guid": "9b08cc14-42a9-4864-976d-caf00469f6cd",
+  "created_at": "2025-07-10T16:27:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/91db43ce-0b44-4b1d-83dc-59200ef9699f.json
+++ b/.github/issue-updates/91db43ce-0b44-4b1d-83dc-59200ef9699f.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement stale ticket workflow",
+  "body": "Use actions/stale to manage inactive issues",
+  "labels": ["automation", "workflow"],
+  "guid": "91db43ce-0b44-4b1d-83dc-59200ef9699f",
+  "legacy_guid": "create-implement-stale-ticket-workflow-2025-07-10"
+}

--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -1,0 +1,62 @@
+# file: .github/workflows/reusable-stale.yml
+# version: 1.0.0
+# guid: 8d2f38b2-1a07-4cd4-9c17-3e77c21f1f1e
+
+name: Reusable - Stale Issue Handler
+
+on:
+  workflow_call:
+    inputs:
+      days-before-stale:
+        description: "Days of inactivity before marking issue stale"
+        required: false
+        default: 60
+        type: number
+      days-before-close:
+        description: "Days after stale before closing issue"
+        required: false
+        default: 7
+        type: number
+      stale-issue-message:
+        description: "Message posted when issue marked stale"
+        required: false
+        default: |
+          This issue is stale because it has been open for ${{ inputs.days-before-stale }} days with no activity.
+          Add a comment to keep it open, or it will be closed in ${{ inputs.days-before-close }} days.
+        type: string
+      close-issue-message:
+        description: "Message posted when issue closed"
+        required: false
+        default: |
+          Closing as stale. Please reopen if still relevant.
+        type: string
+      stale-issue-label:
+        description: "Label to use when marking issue stale"
+        required: false
+        default: "status: stale"
+        type: string
+    secrets:
+      github-token:
+        description: "GitHub token with permissions to manage issues"
+        required: false
+
+jobs:
+  mark-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Run stale action
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
+          days-before-stale: ${{ inputs.days-before-stale }}
+          days-before-close: ${{ inputs.days-before-close }}
+          stale-issue-message: ${{ inputs.stale-issue-message }}
+          close-issue-message: ${{ inputs.close-issue-message }}
+          stale-issue-label: ${{ inputs.stale-issue-label }}
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-pr-label: ''
+          operations-per-run: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+# file: .github/workflows/stale.yml
+# version: 1.0.0
+# guid: 336b7a2d-c53a-4ef2-927e-3bdfd733c528
+
+name: Handle Stale Issues
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  call-stale:
+    uses: ./.github/workflows/reusable-stale.yml
+    with:
+      days-before-stale: 90
+      days-before-close: 14
+    secrets:
+      github-token: ${{ secrets.JF_CI_GH_PAT }}
+


### PR DESCRIPTION
## Summary
Adds a reusable workflow using the official `actions/stale` action and a repository workflow that schedules it weekly. Documentation and issue tracking updates were generated with the provided scripts.

## Issues Addressed

### ci(stale): introduce stale issue workflows (#0)
**Description:** Created a reusable workflow to mark and close stale issues and a calling workflow scheduled weekly. Added docs and TODO entries via automation.

**Files Modified:**
- [`.github/workflows/reusable-stale.yml`](./.github/workflows/reusable-stale.yml) - reusable workflow implementation | [[diff]](../../pull/PR_NUMBER/files#diff-1) [[repo]](../../blob/main/.github/workflows/reusable-stale.yml)
- [`.github/workflows/stale.yml`](./.github/workflows/stale.yml) - scheduled workflow to call the reusable action | [[diff]](../../pull/PR_NUMBER/files#diff-2) [[repo]](../../blob/main/.github/workflows/stale.yml)
- [`.github/doc-updates/4cf31955-2ea0-4781-a0a6-a1119b6a4812.json`](./.github/doc-updates/4cf31955-2ea0-4781-a0a6-a1119b6a4812.json) - changelog entry | [[diff]](../../pull/PR_NUMBER/files#diff-3) [[repo]](../../blob/main/.github/doc-updates/4cf31955-2ea0-4781-a0a6-a1119b6a4812.json)
- [`.github/doc-updates/5f5c45b5-4c04-431b-b4c9-f68325930a17.json`](./.github/doc-updates/5f5c45b5-4c04-431b-b4c9-f68325930a17.json) - TODO update | [[diff]](../../pull/PR_NUMBER/files#diff-4) [[repo]](../../blob/main/.github/doc-updates/5f5c45b5-4c04-431b-b4c9-f68325930a17.json)
- [`.github/doc-updates/9b08cc14-42a9-4864-976d-caf00469f6cd.json`](./.github/doc-updates/9b08cc14-42a9-4864-976d-caf00469f6cd.json) - README update | [[diff]](../../pull/PR_NUMBER/files#diff-5) [[repo]](../../blob/main/.github/doc-updates/9b08cc14-42a9-4864-976d-caf00469f6cd.json)
- [`.github/issue-updates/91db43ce-0b44-4b1d-83dc-59200ef9699f.json`](./.github/issue-updates/91db43ce-0b44-4b1d-83dc-59200ef9699f.json) - issue update created for tracking | [[diff]](../../pull/PR_NUMBER/files#diff-6) [[repo]](../../blob/main/.github/issue-updates/91db43ce-0b44-4b1d-83dc-59200ef9699f.json)

## Testing
- `npx commitlint --from=HEAD~1 --to=HEAD --verbose`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_686fe95e60f4832189320ddc4d7835cb