### PR TITLE
Fix AI rebase to use prompt files

### DIFF
--- a/.github/doc-updates/1b20017d-a435-41f5-80b8-9ce0ccf1c7a7.json
+++ b/.github/doc-updates/1b20017d-a435-41f5-80b8-9ce0ccf1c7a7.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Update AI rebase workflow to use file-based prompts",
+  "guid": "1b20017d-a435-41f5-80b8-9ce0ccf1c7a7",
+  "created_at": "2025-07-10T17:24:53Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/31bbebf0-8269-47c5-a156-66049b953198.json
+++ b/.github/doc-updates/31bbebf0-8269-47c5-a156-66049b953198.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "- AI rebase workflow now uses file-based prompts for model inference",
+  "guid": "31bbebf0-8269-47c5-a156-66049b953198",
+  "created_at": "2025-07-10T17:24:46Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7029d2da-e238-43f9-8a2c-9a267a03b446.json
+++ b/.github/doc-updates/7029d2da-e238-43f9-8a2c-9a267a03b446.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- AI rebase workflow now uses file-based prompts to avoid long command lines",
+  "guid": "7029d2da-e238-43f9-8a2c-9a267a03b446",
+  "created_at": "2025-07-10T17:24:50Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/workflows/reusable-ai-rebase.yml
+++ b/.github/workflows/reusable-ai-rebase.yml
@@ -121,6 +121,67 @@ jobs:
           cat conflict_info.txt >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare AI prompts
+        if: steps.conflicts.outputs.has_conflict == 'true'
+        env:
+          PR_BRANCH: ${{ matrix.pr.branch }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+          REPOSITORY: ${{ github.repository }}
+          CONFLICT_INFO: ${{ steps.conflict_info.outputs.conflict_info }}
+        run: |
+          cat <<'EOF' > system_prompt.txt
+          You are an expert software developer and Git merge conflict resolver. You follow these coding standards:
+
+          - Follow the standard file header format with file path, version, and GUID
+          - Use proper documentation and comments
+          - Maintain code quality and consistency
+          - Preserve the intent of both branches being merged
+          - Use conventional commit message format
+          - Follow language-specific best practices
+
+          When resolving conflicts, analyze both versions carefully and create a solution that:
+          1. Maintains functionality from both branches
+          2. Follows the existing code style and patterns
+          3. Resolves conflicts intelligently rather than just picking one side
+          4. Ensures the resulting code compiles and runs correctly
+          EOF
+
+          cat <<EOF > prompt.txt
+          I need help resolving merge conflicts that occurred during a rebase operation.
+
+          **Context:**
+          - Branch: ${PR_BRANCH}
+          - Base: ${BASE_BRANCH}
+          - Repository: ${REPOSITORY}
+
+          **Conflict Information:**
+          ${CONFLICT_INFO}
+
+          **Instructions:**
+          1. Analyze the conflicts in each file
+          2. Resolve them by combining changes intelligently
+          3. Provide a unified diff patch that can be applied with \`git apply\`
+          4. Ensure the patch resolves ALL conflicts
+          5. Make sure the resulting code follows the project's coding standards
+
+          **Expected Output:**
+          Provide ONLY the git patch in unified diff format, starting with the file headers.
+          Do not include any explanatory text before or after the patch.
+
+          Example format:
+          ```
+          diff --git a/file.ext b/file.ext
+          index abc123..def456 100644
+          --- a/file.ext
+          +++ b/file.ext
+          @@ -1,5 +1,5 @@
+           line1
+          -old line
+          +new line
+           line3
+          ```
+          EOF
+
       - name: Generate patch with AI
         if: steps.conflicts.outputs.has_conflict == 'true'
         id: ai
@@ -128,56 +189,9 @@ jobs:
         with:
           token: ${{ secrets.github-token }}
           model: ${{ inputs.model }}
-          system-prompt: |
-            You are an expert software developer and Git merge conflict resolver. You follow these coding standards:
-
-            - Follow the standard file header format with file path, version, and GUID
-            - Use proper documentation and comments
-            - Maintain code quality and consistency
-            - Preserve the intent of both branches being merged
-            - Use conventional commit message format
-            - Follow language-specific best practices
-
-            When resolving conflicts, analyze both versions carefully and create a solution that:
-            1. Maintains functionality from both branches
-            2. Follows the existing code style and patterns
-            3. Resolves conflicts intelligently rather than just picking one side
-            4. Ensures the resulting code compiles and runs correctly
+          system-prompt-file: system_prompt.txt
+          prompt-file: prompt.txt
           max-tokens: 4000
-          prompt: |
-            I need help resolving merge conflicts that occurred during a rebase operation.
-
-            **Context:**
-            - Branch: ${{ matrix.pr.branch }}
-            - Base: ${{ inputs.base-branch }}
-            - Repository: ${{ github.repository }}
-
-            **Conflict Information:**
-            ${{ steps.conflict_info.outputs.conflict_info }}
-
-            **Instructions:**
-            1. Analyze the conflicts in each file
-            2. Resolve them by combining changes intelligently
-            3. Provide a unified diff patch that can be applied with `git apply`
-            4. Ensure the patch resolves ALL conflicts
-            5. Make sure the resulting code follows the project's coding standards
-
-            **Expected Output:**
-            Provide ONLY the git patch in unified diff format, starting with the file headers.
-            Do not include any explanatory text before or after the patch.
-
-            Example format:
-            ```
-            diff --git a/file.ext b/file.ext
-            index abc123..def456 100644
-            --- a/file.ext
-            +++ b/file.ext
-            @@ -1,5 +1,5 @@
-             line1
-            -old line
-            +new line
-             line3
-            ```
 
       - name: Apply AI patch
         if: steps.conflicts.outputs.has_conflict == 'true'


### PR DESCRIPTION
## Summary
- refactor AI rebase workflow to generate prompt files for model inference
- note the change in README
- add changelog entry and TODO task via doc update system

## Issues Addressed

### ci(ai-rebase): use prompt files for ai inference (#0)

**Description:** Updated reusable AI rebase workflow to write system and user prompts to files, then pass those to `actions/ai-inference`. Added doc update JSON files for README, CHANGELOG, and TODO.

**Files Modified:**
- [`.github/workflows/reusable-ai-rebase.yml`](./.github/workflows/reusable-ai-rebase.yml) - generate prompt files and reference them | [[diff]](../../pull/PR_NUMBER/files#diff-6e42e0) [[repo]](../../blob/main/.github/workflows/reusable-ai-rebase.yml)
- [`.github/doc-updates/31bbebf0-8269-47c5-a156-66049b953198.json`](./.github/doc-updates/31bbebf0-8269-47c5-a156-66049b953198.json) - README update | [[diff]](../../pull/PR_NUMBER/files#diff-8b42ee) [[repo]](../../blob/main/.github/doc-updates/31bbebf0-8269-47c5-a156-66049b953198.json)
- [`.github/doc-updates/7029d2da-e238-43f9-8a2c-9a267a03b446.json`](./.github/doc-updates/7029d2da-e238-43f9-8a2c-9a267a03b446.json) - changelog entry | [[diff]](../../pull/PR_NUMBER/files#diff-7d0e1f) [[repo]](../../blob/main/.github/doc-updates/7029d2da-e238-43f9-8a2c-9a267a03b446.json)
- [`.github/doc-updates/1b20017d-a435-41f5-80b8-9ce0ccf1c7a7.json`](./.github/doc-updates/1b20017d-a435-41f5-80b8-9ce0ccf1c7a7.json) - TODO task update | [[diff]](../../pull/PR_NUMBER/files#diff-ab6036) [[repo]](../../blob/main/.github/doc-updates/1b20017d-a435-41f5-80b8-9ce0ccf1c7a7.json)

## Testing
- `npm run commitlint`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_686ff66c95e48321a8db585d4f132c0a