### PR TITLE
Add shared rebase system prompt

### DIFF
--- a/.github/doc-updates/4f7d15ef-550f-420e-9010-d74a2e6326a7.json
+++ b/.github/doc-updates/4f7d15ef-550f-420e-9010-d74a2e6326a7.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Propagate shared system prompt file to all repos",
+  "guid": "4f7d15ef-550f-420e-9010-d74a2e6326a7",
+  "created_at": "2025-07-10T22:29:00Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/b5ba519c-7154-4766-9dd5-2d06ab1b70a2.json
+++ b/.github/doc-updates/b5ba519c-7154-4766-9dd5-2d06ab1b70a2.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Common system prompt file for AI rebase workflow",
+  "guid": "b5ba519c-7154-4766-9dd5-2d06ab1b70a2",
+  "created_at": "2025-07-10T22:28:45Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/d625d3a0-089e-4647-a252-5056f25b5ade.json
+++ b/.github/doc-updates/d625d3a0-089e-4647-a252-5056f25b5ade.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Document shared AI rebase system prompt",
+  "guid": "d625d3a0-089e-4647-a252-5056f25b5ade",
+  "created_at": "2025-07-10T22:28:52Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/prompts/ai-rebase-system.prompt.md
+++ b/.github/prompts/ai-rebase-system.prompt.md
@@ -1,0 +1,18 @@
+<!-- file: .github/prompts/ai-rebase-system.prompt.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2b99c940-4a0d-4f2a-9e09-cbba1ac5727d -->
+
+You are an expert software developer and Git merge conflict resolver. You follow these coding standards:
+
+- Follow the standard file header format with file path, version, and GUID
+- Use proper documentation and comments
+- Maintain code quality and consistency
+- Preserve the intent of both branches being merged
+- Use conventional commit message format
+- Follow language-specific best practices
+
+When resolving conflicts, analyze both versions carefully and create a solution that:
+1. Maintains functionality from both branches
+2. Follows the existing code style and patterns
+3. Resolves conflicts intelligently rather than just picking one side
+4. Ensures the resulting code compiles and runs correctly

--- a/.github/workflows/reusable-ai-rebase.yml
+++ b/.github/workflows/reusable-ai-rebase.yml
@@ -134,7 +134,11 @@ jobs:
           cat conflict_info.txt >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare AI prompts
+      - name: Prepare system prompt
+        if: steps.conflicts.outputs.has_conflict == 'true'
+        run: cp .github/prompts/ai-rebase-system.prompt.md system_prompt.txt
+
+      - name: Prepare AI prompt
         if: steps.conflicts.outputs.has_conflict == 'true'
         env:
           PR_BRANCH: ${{ matrix.pr.branch }}
@@ -142,30 +146,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           CONFLICT_INFO: ${{ steps.conflict_info.outputs.conflict_info }}
         run: |
-          # Create system prompt in multiple blocks
-          cat <<'SYSTEM_EOF1' > system_prompt.txt
-          You are an expert software developer and Git merge conflict resolver. You follow these coding standards:
-
-          - Follow the standard file header format with file path, version, and GUID
-          - Use proper documentation and comments
-          - Maintain code quality and consistency
-          - Preserve the intent of both branches being merged
-          SYSTEM_EOF1
-
-          cat <<'SYSTEM_EOF2' >> system_prompt.txt
-          - Use conventional commit message format
-          - Follow language-specific best practices
-
-          When resolving conflicts, analyze both versions carefully and create a solution that:
-          1. Maintains functionality from both branches
-          2. Follows the existing code style and patterns
-          SYSTEM_EOF2
-
-          cat <<'SYSTEM_EOF3' >> system_prompt.txt
-          3. Resolves conflicts intelligently rather than just picking one side
-          4. Ensures the resulting code compiles and runs correctly
-          SYSTEM_EOF3
-
           # Create prompt in multiple blocks
           cat <<PROMPT_EOF1 > prompt.txt
           I need help resolving merge conflicts that occurred during a rebase operation.


### PR DESCRIPTION
## Summary
- introduce `ai-rebase-system.prompt.md`
- copy the shared prompt in `reusable-ai-rebase.yml`
- generate doc updates for README, CHANGELOG, and TODO

## Testing
- `python -m pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68703d95fe8c83218e4a5645109101df