### PR TITLE
Fix docs update workflow syntax error

### DIFF
--- a/.github/doc-updates/39cfeb9b-dc1b-4bc6-927f-80ed55608d39.json
+++ b/.github/doc-updates/39cfeb9b-dc1b-4bc6-927f-80ed55608d39.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "Fix doc update workflow syntax error",
+  "guid": "39cfeb9b-dc1b-4bc6-927f-80ed55608d39",
+  "created_at": "2025-07-14T01:34:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bb90e70c-00fc-4abe-99a7-92edf540e83b.json
+++ b/.github/doc-updates/bb90e70c-00fc-4abe-99a7-92edf540e83b.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Fix syntax error in reusable docs update workflow",
+  "guid": "bb90e70c-00fc-4abe-99a7-92edf540e83b",
+  "created_at": "2025-07-14T01:34:33Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/c2f69662-1d12-411a-bb8a-d2e6e66557b9.json
+++ b/.github/doc-updates/c2f69662-1d12-411a-bb8a-d2e6e66557b9.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "Track fix for docs workflow",
+  "guid": "c2f69662-1d12-411a-bb8a-d2e6e66557b9",
+  "created_at": "2025-07-14T01:34:51Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/workflows/reusable-docs-update.yml
+++ b/.github/workflows/reusable-docs-update.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-docs-update.yml
-# version: 2.0.0
+# version: 2.0.1
 # guid: 25b987e1-9e34-4618-8182-53e12c7307e0
 
 name: Reusable Documentation Updates
@@ -205,11 +205,6 @@ jobs:
           echo "changes_made=false" >> "$GITHUB_OUTPUT"
 
           echo "📈 Summary: Documentation update completed (detailed stats disabled)"
-          else
-            echo "⚠️ No stats file generated"
-            echo "files_processed=0" >> "$GITHUB_OUTPUT"
-            echo "changes_made=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Generate update summary
         if: steps.validate.outputs.files_found > 0


### PR DESCRIPTION
## Summary
- remove stray `else` from `reusable-docs-update.yml`
- add documentation update entries for README, CHANGELOG, and TODO

## Testing
- `npm run commitlint`

------
https://chatgpt.com/codex/tasks/task_e_68745dae11388321b40ac7cae4380b19