### PR TITLE
Add manual unified automation options

### DIFF
--- a/.github/doc-updates/0368d63f-0499-4dee-9b4c-34faf0cf29fa.json
+++ b/.github/doc-updates/0368d63f-0499-4dee-9b4c-34faf0cf29fa.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "| [`reusable-unified-automation.yml`](.github/workflows/reusable-unified-automation.yml) | Unified automation orchestrator | Runs issue management, docs update, labeler, linting, and AI rebase |",
+  "guid": "0368d63f-0499-4dee-9b4c-34faf0cf29fa",
+  "created_at": "2025-07-16T10:20:53Z",
+  "options": {
+    "section": null,
+    "after": "| [`unified-issue-management.yml`](.github/workflows/reusable-unified-issue-management.yml) | Comprehensive issue management |",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/0baeaacd-ddf8-4e58-b41a-31975362ee38.json
+++ b/.github/doc-updates/0baeaacd-ddf8-4e58-b41a-31975362ee38.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Validate manual unified automation workflow inputs",
+  "guid": "0baeaacd-ddf8-4e58-b41a-31975362ee38",
+  "created_at": "2025-07-16T13:57:37Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/19191193-6adb-4d52-abb0-89ecffade4af.json
+++ b/.github/doc-updates/19191193-6adb-4d52-abb0-89ecffade4af.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added comprehensive manual unified automation workflow options",
+  "guid": "19191193-6adb-4d52-abb0-89ecffade4af",
+  "created_at": "2025-07-16T13:57:20Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/683a1cba-5d5e-42be-a9a2-4bdff9cfae81.json
+++ b/.github/doc-updates/683a1cba-5d5e-42be-a9a2-4bdff9cfae81.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added unified automation workflow for manual invocation",
+  "guid": "683a1cba-5d5e-42be-a9a2-4bdff9cfae81",
+  "created_at": "2025-07-16T10:21:27Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/89f3d882-cc25-479f-9e5a-f1702263bb1b.json
+++ b/.github/doc-updates/89f3d882-cc25-479f-9e5a-f1702263bb1b.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Add dedicated unified automation workflow",
+  "guid": "89f3d882-cc25-479f-9e5a-f1702263bb1b",
+  "created_at": "2025-07-16T10:21:32Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/9ad175b2-7d31-4caf-83cd-c6ddecc5efcb.json
+++ b/.github/doc-updates/9ad175b2-7d31-4caf-83cd-c6ddecc5efcb.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "insert-after",
+  "content": "| [`unified-automation.yml`](.github/workflows/unified-automation.yml) | Standalone workflow to run unified automation | Manual trigger with extensive options |",
+  "guid": "9ad175b2-7d31-4caf-83cd-c6ddecc5efcb",
+  "created_at": "2025-07-16T13:57:17Z",
+  "options": {
+    "section": null,
+    "after": "| [`reusable-unified-automation.yml`](.github/workflows/reusable-unified-automation.yml) | Unified automation orchestrator | Runs issue management, docs update, labeler, linting, and AI rebase |",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ebbf092b-1925-4702-a77f-97752761857b.json
+++ b/.github/doc-updates/ebbf092b-1925-4702-a77f-97752761857b.json
@@ -1,0 +1,16 @@
+{
+  "file": "docs/unified-automation.md",
+  "mode": "insert-after",
+  "content": "**Tip:** Use the `unified-automation.yml` workflow in your repository to manually run or schedule the orchestrator.",
+  "guid": "ebbf092b-1925-4702-a77f-97752761857b",
+  "created_at": "2025-07-16T10:21:12Z",
+  "options": {
+    "section": null,
+    "after": "For a minimal example see [`examples/workflows/unified-automation.yml`](../examples/workflows/unified-automation.yml).",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/ef849c9d-1059-41b1-b25b-b9f6f21c49a9.json
+++ b/.github/doc-updates/ef849c9d-1059-41b1-b25b-b9f6f21c49a9.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "Removed manual workflow_dispatch trigger from reusable-unified-automation.yml",
+  "guid": "ef849c9d-1059-41b1-b25b-b9f6f21c49a9",
+  "created_at": "2025-07-16T10:21:30Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/f0faf6de-fbe7-403c-b829-f3aebc78f280.json
+++ b/.github/doc-updates/f0faf6de-fbe7-403c-b829-f3aebc78f280.json
@@ -1,0 +1,16 @@
+{
+  "file": "docs/unified-automation.md",
+  "mode": "insert-after",
+  "content": "The `unified-automation.yml` workflow exposes the same inputs for manual invocation.",
+  "guid": "f0faf6de-fbe7-403c-b829-f3aebc78f280",
+  "created_at": "2025-07-16T13:57:40Z",
+  "options": {
+    "section": null,
+    "after": "For a minimal example see [`examples/workflows/unified-automation.yml`](../examples/workflows/unified-automation.yml).",
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/workflows/reusable-unified-automation.yml
+++ b/.github/workflows/reusable-unified-automation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-unified-automation.yml
-# version: 2.2.1
+# version: 2.4.0
 # guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 name: Unified Automation Orchestrator
@@ -206,10 +206,6 @@ on:
         required: false
         default: "openai/gpt-4o"
         type: string
-    secrets:
-      github-token:
-        description: "GitHub token for authentication"
-        required: true
 
 jobs:
   issue-management:

--- a/.github/workflows/unified-automation.yml
+++ b/.github/workflows/unified-automation.yml
@@ -1,8 +1,25 @@
 # file: .github/workflows/unified-automation.yml
-# version: 1.5.0
+# version: 2.0.0
 # guid: 9e8f7a6b-5c4d-3b2a-1e0f-9d8c7b6a5e4f
+#
+# Unified Automation Workflow
+#
+# This workflow triggers the reusable automation orchestrator in ghcommon.
 
-name: Unified Automation Entrypoint
+name: Unified Automation
+
+permissions:
+  contents: write # For creating commits and PRs
+  issues: write # For creating and updating issues
+  pull-requests: write # For creating PRs
+  security-events: write # For security scanning and writing results
+  repository-projects: write # For adding items to projects
+  actions: write # For workflow access
+  checks: write # For workflow status
+  statuses: write # For commit status updates
+  packages: read # For package access (required by super-linter)
+  id-token: write # For attestation and artifact uploads (required by super-linter)
+  models: read # For AI model access (required by ai-rebase)
 
 on:
   push:
@@ -14,25 +31,103 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: "Which operation(s) to run (all, issues, docs, label, lint, rebase)"
+        description: "Which automation tasks to run"
         required: false
-        default: "all"
         type: string
+        default: "all"
       im_operations:
         description: "Operations for issue management workflow"
         required: false
         default: "auto"
         type: string
+      im_dry_run:
+        description: "Run issue management in dry-run mode"
+        required: false
+        default: false
+        type: boolean
+      im_force_update:
+        description: "Force update existing issues"
+        required: false
+        default: false
+        type: boolean
+      im_issue_updates_file:
+        description: "Path to legacy issue updates file"
+        required: false
+        default: "issue_updates.json"
+        type: string
+      im_issue_updates_directory:
+        description: "Directory containing distributed issue updates"
+        required: false
+        default: ".github/issue-updates"
+        type: string
+      im_cleanup_issue_updates:
+        description: "Cleanup processed issue update files"
+        required: false
+        default: true
+        type: boolean
+      im_python_version:
+        description: "Python version for issue management"
+        required: false
+        default: "3.11"
+        type: string
+
       docs_updates_directory:
         description: "Directory with documentation updates"
         required: false
         default: ".github/doc-updates"
         type: string
+      docs_dry_run:
+        description: "Run docs update in dry-run mode"
+        required: false
+        default: false
+        type: boolean
+      docs_python_version:
+        description: "Python version for docs update"
+        required: false
+        default: "3.11"
+        type: string
+      docs_cleanup_processed_files:
+        description: "Cleanup processed doc update files"
+        required: false
+        default: true
+        type: boolean
+      docs_create_pr:
+        description: "Create PR for documentation changes"
+        required: false
+        default: false
+        type: boolean
+      docs_auto_merge:
+        description: "Auto-merge documentation PRs"
+        required: false
+        default: false
+        type: boolean
+      docs_continue_on_error:
+        description: "Continue processing even if some updates fail"
+        required: false
+        default: true
+        type: boolean
+
       labeler_configuration_path:
         description: "Path to labeler configuration"
         required: false
         default: ".github/labeler.yml"
         type: string
+      labeler_sync_labels:
+        description: "Remove labels when files are reverted"
+        required: false
+        default: false
+        type: boolean
+      labeler_dot:
+        description: "Include dot files when labeling"
+        required: false
+        default: true
+        type: boolean
+      labeler_pr_numbers:
+        description: "Specific PR numbers to label"
+        required: false
+        default: ""
+        type: string
+
       sl_validate_all_codebase:
         description: "Validate entire codebase with Super Linter"
         required: false
@@ -48,41 +143,134 @@ on:
         required: false
         default: ".github/super-linter.env"
         type: string
+      sl_run_python:
+        description: "Enable Python linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_shell:
+        description: "Enable shell linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_markdown:
+        description: "Enable Markdown linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_yaml:
+        description: "Enable YAML linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_json:
+        description: "Enable JSON linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_javascript:
+        description: "Enable JavaScript linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_go:
+        description: "Enable Go linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_css:
+        description: "Enable CSS linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_html:
+        description: "Enable HTML linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_protobuf:
+        description: "Enable Protobuf linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_github_actions:
+        description: "Enable GitHub Actions linting"
+        required: false
+        default: true
+        type: boolean
+      sl_run_security:
+        description: "Enable security scanning"
+        required: false
+        default: true
+        type: boolean
+      sl_enable_auto_fix:
+        description: "Enable auto-fixing where supported"
+        required: false
+        default: true
+        type: boolean
+      sl_auto_commit_fixes:
+        description: "Automatically commit lint fixes"
+        required: false
+        default: true
+        type: boolean
+      sl_commit_message:
+        description: "Commit message for lint fixes"
+        required: false
+        default: "style: auto-fix linting issues [skip ci]"
+        type: string
+
       rebase_base_branch:
         description: "Branch to rebase pull requests onto"
         required: false
         default: "main"
         type: string
-      config_json:
-        description: "JSON string containing any additional config options. See README for format."
+      rebase_model:
+        description: "Model to use for AI rebase"
         required: false
-        default: "{}"
+        default: "openai/gpt-4o"
         type: string
 
-permissions:
-  contents: write # For creating commits and PRs
-  issues: write # For creating and updating issues
-  pull-requests: write # For creating PRs
-  security-events: write # For security scanning and writing results
-  repository-projects: write # For adding items to projects
-  actions: write # For workflow access
-  checks: write # For workflow status
-  statuses: write # For commit status updates
-  packages: read # For package access (required by super-linter)
-  id-token: write # For attestation and artifact uploads (required by super-linter)
-  models: read # For AI model access (required by ai-rebase)
-
 jobs:
-  unified-automation:
+  automation:
     uses: jdfalk/ghcommon/.github/workflows/reusable-unified-automation.yml@main
     with:
-      operation: ${{ inputs.operation }}
-      im_operations: ${{ inputs.im_operations }}
-      docs_updates_directory: ${{ inputs.docs_updates_directory }}
-      labeler_configuration_path: ${{ inputs.labeler_configuration_path }}
-      sl_validate_all_codebase: ${{ inputs.sl_validate_all_codebase }}
-      sl_default_branch: ${{ inputs.sl_default_branch }}
-      sl_config_file: ${{ inputs.sl_config_file }}
-      rebase_base_branch: ${{ inputs.rebase_base_branch }}
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      operation: ${{ github.event.inputs.operation || 'all' }}
+      im_operations: ${{ github.event.inputs.im_operations || 'auto' }}
+      im_dry_run: ${{ github.event.inputs.im_dry_run || false }}
+      im_force_update: ${{ github.event.inputs.im_force_update || false }}
+      im_issue_updates_file: ${{ github.event.inputs.im_issue_updates_file || 'issue_updates.json' }}
+      im_issue_updates_directory: ${{ github.event.inputs.im_issue_updates_directory || '.github/issue-updates' }}
+      im_cleanup_issue_updates: ${{ github.event.inputs.im_cleanup_issue_updates || true }}
+      im_python_version: ${{ github.event.inputs.im_python_version || '3.11' }}
+      docs_updates_directory: ${{ github.event.inputs.docs_updates_directory || '.github/doc-updates' }}
+      docs_dry_run: ${{ github.event.inputs.docs_dry_run || false }}
+      docs_python_version: ${{ github.event.inputs.docs_python_version || '3.11' }}
+      docs_cleanup_processed_files: ${{ github.event.inputs.docs_cleanup_processed_files || true }}
+      docs_create_pr: ${{ github.event.inputs.docs_create_pr || false }}
+      docs_auto_merge: ${{ github.event.inputs.docs_auto_merge || false }}
+      docs_continue_on_error: ${{ github.event.inputs.docs_continue_on_error || true }}
+      labeler_configuration_path: ${{ github.event.inputs.labeler_configuration_path || '.github/labeler.yml' }}
+      labeler_sync_labels: ${{ github.event.inputs.labeler_sync_labels || false }}
+      labeler_dot: ${{ github.event.inputs.labeler_dot || true }}
+      labeler_pr_numbers: ${{ github.event.inputs.labeler_pr_numbers || '' }}
+      sl_validate_all_codebase: ${{ github.event.inputs.sl_validate_all_codebase || false }}
+      sl_default_branch: ${{ github.event.inputs.sl_default_branch || 'main' }}
+      sl_config_file: ${{ github.event.inputs.sl_config_file || '.github/super-linter.env' }}
+      sl_run_python: ${{ github.event.inputs.sl_run_python || true }}
+      sl_run_shell: ${{ github.event.inputs.sl_run_shell || true }}
+      sl_run_markdown: ${{ github.event.inputs.sl_run_markdown || true }}
+      sl_run_yaml: ${{ github.event.inputs.sl_run_yaml || true }}
+      sl_run_json: ${{ github.event.inputs.sl_run_json || true }}
+      sl_run_javascript: ${{ github.event.inputs.sl_run_javascript || true }}
+      sl_run_go: ${{ github.event.inputs.sl_run_go || true }}
+      sl_run_css: ${{ github.event.inputs.sl_run_css || true }}
+      sl_run_html: ${{ github.event.inputs.sl_run_html || true }}
+      sl_run_protobuf: ${{ github.event.inputs.sl_run_protobuf || true }}
+      sl_run_github_actions: ${{ github.event.inputs.sl_run_github_actions || true }}
+      sl_run_security: ${{ github.event.inputs.sl_run_security || true }}
+      sl_enable_auto_fix: ${{ github.event.inputs.sl_enable_auto_fix || true }}
+      sl_auto_commit_fixes: ${{ github.event.inputs.sl_auto_commit_fixes || true }}
+      sl_commit_message: "${{ github.event.inputs.sl_commit_message || 'style: auto-fix linting issues [skip ci]' }}"
+      rebase_base_branch: ${{ github.event.inputs.rebase_base_branch || 'main' }}
+      rebase_model: ${{ github.event.inputs.rebase_model || 'openai/gpt-4o' }}
+    secrets: inherit

--- a/scripts/issue_manager.py
+++ b/scripts/issue_manager.py
@@ -2457,7 +2457,9 @@ Environment Variables:
         "update-issues", help="Process issue updates from JSON files"
     )
     update_parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be done without executing"
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without executing",
     )
     update_parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose output"
@@ -2473,7 +2475,9 @@ Environment Variables:
         "copilot-tickets", help="Manage Copilot review comment tickets"
     )
     copilot_parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be done without executing"
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without executing",
     )
 
     # Close duplicates command
@@ -2481,7 +2485,9 @@ Environment Variables:
         "close-duplicates", help="Close duplicate issues by title"
     )
     duplicate_parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be done without executing"
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without executing",
     )
 
     # CodeQL alerts command
@@ -2489,7 +2495,9 @@ Environment Variables:
         "codeql-alerts", help="Generate tickets for CodeQL security alerts"
     )
     codeql_parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be done without executing"
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without executing",
     )
 
     # Event handler command
@@ -2521,12 +2529,8 @@ Environment Variables:
 
         # Execute the requested command
         if args.command == "update-issues":
-            processor = IssueUpdateProcessor(api)
-            success = processor.process_updates(
-                directory=args.directory,
-                dry_run=args.dry_run,
-                verbose=getattr(args, "verbose", False),
-            )
+            processor = IssueUpdateProcessor(api, dry_run=args.dry_run)
+            success = processor.process_updates(updates_directory=args.directory)
             return 0 if success else 1
 
         elif args.command == "copilot-tickets":
@@ -2548,9 +2552,11 @@ Environment Variables:
             # For event handler, we need to determine what type of event this is
             event_name = os.getenv("GITHUB_EVENT_NAME")
             if not event_name:
-                print("❌ Error: GITHUB_EVENT_NAME environment variable is required for event handling")
+                print(
+                    "❌ Error: GITHUB_EVENT_NAME environment variable is required for event handling"
+                )
                 return 1
-            
+
             # For now, just handle as issue updates
             processor = IssueUpdateProcessor(api)
             success = processor.process_updates(dry_run=False)
@@ -2564,6 +2570,7 @@ Environment Variables:
         print(f"❌ Error: {e}")
         if getattr(args, "verbose", False):
             import traceback
+
             traceback.print_exc()
         return 1
 


### PR DESCRIPTION
## Summary
- expose every orchestrator input in `unified-automation.yml`
- add documentation updates for the new manual workflow

## Testing
- `npm run commitlint`


------
https://chatgpt.com/codex/tasks/task_e_68777bfe76c08321b6e57c58ae1c0986