### PR TITLE
Add queue protobuf and docs

### DIFF
--- a/.github/doc-updates/64ecd8d7-6597-40df-a995-e85b08d78b4d.json
+++ b/.github/doc-updates/64ecd8d7-6597-40df-a995-e85b08d78b4d.json
@@ -1,0 +1,16 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Added initial queue module protobuf definitions",
+  "guid": "64ecd8d7-6597-40df-a995-e85b08d78b4d",
+  "created_at": "2025-07-22T16:18:44Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/7eaab99f-5c73-4801-b788-f5581df9a713.json
+++ b/.github/doc-updates/7eaab99f-5c73-4801-b788-f5581df9a713.json
@@ -1,0 +1,16 @@
+{
+  "file": "TODO.md",
+  "mode": "task-add",
+  "content": "- [ ] 🟡 **General**: Implement advanced queue protobuf features",
+  "guid": "7eaab99f-5c73-4801-b788-f5581df9a713",
+  "created_at": "2025-07-22T16:18:38Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/bcc0e8c4-7566-45e1-9af7-3ff96bc0a38f.json
+++ b/.github/doc-updates/bcc0e8c4-7566-45e1-9af7-3ff96bc0a38f.json
@@ -1,0 +1,16 @@
+{
+  "file": "README.md",
+  "mode": "append",
+  "content": "## Queue Module\\n\\nTODO: Add content for this section",
+  "guid": "bcc0e8c4-7566-45e1-9af7-3ff96bc0a38f",
+  "created_at": "2025-07-22T16:18:40Z",
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/0ac90c1c-bed2-414b-9678-79bc71a2ac53.json
+++ b/.github/issue-updates/0ac90c1c-bed2-414b-9678-79bc71a2ac53.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Implement queue protobufs",
+  "body": "Added queue proto definitions",
+  "labels": ["module:queue", "tech:protobuf"],
+  "guid": "0ac90c1c-bed2-414b-9678-79bc71a2ac53",
+  "legacy_guid": "create-implement-queue-protobufs-2025-07-22"
+}

--- a/PACKAGE_NAMING_RESOLUTION.md
+++ b/PACKAGE_NAMING_RESOLUTION.md
@@ -1,0 +1,15 @@
+<!-- file: PACKAGE_NAMING_RESOLUTION.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7dbb26f1-96fb-42db-bae1-38799f9a0012 -->
+
+# Package Naming Resolution
+
+This document tracks the agreed-upon package naming conventions for all gcommon protobuf definitions.
+
+## Conventions
+
+- All packages follow the format `gcommon.v1.<module>`.
+- Go package option uses the module path `github.com/jdfalk/gcommon/proto/gcommon/v1` with an appropriate import alias.
+- Edition 2023 is required for all proto files.
+
+These rules ensure consistency across modules as we complete remaining protobuf implementations.

--- a/PROTOBUF_HANDOFF_COMPLETE.md
+++ b/PROTOBUF_HANDOFF_COMPLETE.md
@@ -1,0 +1,13 @@
+<!-- file: PROTOBUF_HANDOFF_COMPLETE.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 25deaa37-7bb6-4b70-9134-6aad3890ccee -->
+
+# Protobuf Handoff Complete
+
+This document records protobuf files handed off from planning to implementation.
+
+## Completed Modules
+
+- Queue: initial service and message definitions implemented in `proto/gcommon/v1/queue.proto`.
+
+Further modules will be marked here as they are completed.

--- a/PROTOBUF_IMPLEMENTATION_PLAN.md
+++ b/PROTOBUF_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,27 @@
+<!-- file: PROTOBUF_IMPLEMENTATION_PLAN.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2c728c3d-59c7-4e7a-93f1-6221b100edb5 -->
+
+# Protobuf Implementation Plan
+
+This plan tracks progress on implementing protobuf definitions across the gcommon modules.
+
+## Modules Overview
+
+| Module | Files Remaining | Status |
+|-------|----------------|--------|
+| Metrics | 95 | Pending |
+| Queue | 175 | In Progress |
+| Web | 176 | Pending |
+| Auth | 109 | Pending |
+| Cache | 36 | Pending |
+| Config | 20 | Pending |
+
+## Recent Work
+
+- Implemented initial `queue.proto` providing service and message definitions for queue operations.
+
+## Next Steps
+
+- Flesh out advanced queue message types such as delayed delivery and priority handling.
+- Begin designing metrics module protobufs.

--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -1,0 +1,11 @@
+<!-- file: SESSION_SUMMARY.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d04a0da1-d83c-4e27-b5e7-2c6d99a1ec0b -->
+
+# Session Summary
+
+This development session added initial protobuf definitions for the Queue module and updated project documentation accordingly.
+
+- Created `queue.proto` implementing basic queue operations.
+- Documented naming conventions and implementation plan.
+- Noted completion in the protobuf handoff record.

--- a/proto/gcommon/v1/queue.proto
+++ b/proto/gcommon/v1/queue.proto
@@ -1,0 +1,63 @@
+// file: proto/gcommon/v1/queue.proto
+// version: 1.0.0
+// guid: e1209e8d-4fe2-4b4c-8e0a-33e998b50b8a
+syntax = "proto3";
+package gcommon.v1;
+edition = "2023";
+
+option go_package = "github.com/jdfalk/gcommon/proto/gcommon/v1;gcommonv1";
+
+// QueueItem represents a single item in the queue.
+message QueueItem {
+  // Unique identifier for the item.
+  string id = 1;
+
+  // Payload data associated with the item.
+  bytes data = 2;
+
+  // Optional metadata for routing or processing.
+  map<string, string> metadata = 3;
+}
+
+// EnqueueRequest adds an item to the queue.
+message EnqueueRequest {
+  QueueItem item = 1; // Item to enqueue.
+}
+
+// EnqueueResponse contains the enqueued item's identifier.
+message EnqueueResponse {
+  string id = 1; // Identifier assigned to the enqueued item.
+}
+
+// DequeueRequest retrieves the next item from the queue.
+message DequeueRequest {
+  // Maximum number of items to return.
+  uint32 max_items = 1;
+}
+
+// DequeueResponse returns one or more queued items.
+message DequeueResponse {
+  repeated QueueItem items = 1; // Items dequeued from the queue.
+}
+
+// AcknowledgeRequest acknowledges successful processing of an item.
+message AcknowledgeRequest {
+  repeated string ids = 1; // Identifiers of items to acknowledge.
+}
+
+// AcknowledgeResponse confirms acknowledgement.
+message AcknowledgeResponse {
+  repeated string acknowledged_ids = 1; // Acknowledged item identifiers.
+}
+
+// QueueService defines basic queue operations.
+service QueueService {
+  // Enqueue adds an item to the queue and returns its identifier.
+  rpc Enqueue(EnqueueRequest) returns (EnqueueResponse);
+
+  // Dequeue retrieves items from the queue for processing.
+  rpc Dequeue(DequeueRequest) returns (DequeueResponse);
+
+  // Acknowledge confirms processing of items and removes them from the queue.
+  rpc Acknowledge(AcknowledgeRequest) returns (AcknowledgeResponse);
+}


### PR DESCRIPTION
## Summary
- introduce queue.proto for message queue operations
- document package naming conventions
- outline protobuf implementation plan and handoff status
- log session summary
- queue protobuf work noted in issue/TODO/CHANGELOG via update scripts

## Testing
- `./.github/validate-setup.sh` *(fails: No git remote origin)*

------
https://chatgpt.com/codex/tasks/task_e_687fb88e76348321a6fdd75d27097133