### PR TITLE
fix: enforce super linter auto-fixes before CI jobs

### DIFF
--- a/.github/doc-updates/processed/20250806_235234_7c10a8ce-6a2d-4e01-9331-5ace6048c370.json
+++ b/.github/doc-updates/processed/20250806_235234_7c10a8ce-6a2d-4e01-9331-5ace6048c370.json
@@ -1,0 +1,20 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\\n- Ensure Super Linter auto-fixes issues, pushes commits, runs before other jobs, and validates entire codebase",
+  "guid": "7c10a8ce-6a2d-4e01-9331-5ace6048c370",
+  "created_at": "2025-08-06T23:52:31Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null,
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/doc-updates/processed/20250806_235319_a4d993f9-da4f-48c4-bca3-773227ee22a0.json
+++ b/.github/doc-updates/processed/20250806_235319_a4d993f9-da4f-48c4-bca3-773227ee22a0.json
@@ -1,0 +1,20 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Fixed\n\n- Ensure Super Linter auto-fixes issues, pushes commits, runs before other jobs, and validates entire codebase",
+  "guid": "a4d993f9-da4f-48c4-bca3-773227ee22a0",
+  "created_at": "2025-08-06T23:53:14Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null,
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/.github/issue-updates/db0e0733-eca5-461e-baf5-137df58f89c3.json
+++ b/.github/issue-updates/db0e0733-eca5-461e-baf5-137df58f89c3.json
@@ -1,0 +1,8 @@
+{
+  "action": "create",
+  "title": "Improve Super Linter workflows",
+  "body": "Ensure Super Linter auto-fixes lint issues, pushes results, runs before other jobs, and validates entire codebase.",
+  "labels": ["automation", "github-actions"],
+  "guid": "db0e0733-eca5-461e-baf5-137df58f89c3",
+  "legacy_guid": "create-improve-super-linter-workflows-2025-08-06"
+}

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -1,5 +1,5 @@
 # file: .github/super-linter.env
-# version: 1.0.5
+# version: 1.0.6
 # guid: c1d2e3f4-a5b6-789c-def0-123456789abc
 
 # Super Linter Configuration
@@ -7,7 +7,7 @@
 
 # General Settings
 DEFAULT_BRANCH=main
-VALIDATE_ALL_CODEBASE=false
+VALIDATE_ALL_CODEBASE=true
 FILTER_REGEX_EXCLUDE=.*\.git/.*|.*\.github/copilot/.*|.*\.vscode/.*|.*node_modules/.*|.*\.cache/.*
 
 # Language Settings - Only specify linters to ENABLE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 1.1.0
+# version: 1.1.1
 # guid: b8c9d0e1-f2a3-44b5-c6d7-e8f9a0b1c2d3
 
 name: CI
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 jobs:
   ci:
     uses: ./.github/workflows/reusable-ci.yml

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/pr-automation.yml
-# version: 2.1.0
+# version: 2.1.1
 # guid: a7b8c9d0-e1f2-3456-a789-0123456789bc
 
 name: PR Automation
@@ -27,8 +27,9 @@ jobs:
     name: Code Quality Check
     uses: jdfalk/ghcommon/.github/workflows/reusable-super-linter.yml@main
     with:
-      validate-all-codebase: false
+      validate-all-codebase: true
       default-branch: ${{ github.event.repository.default_branch }}
+      config-file: .github/super-linter.env
       filter-regex-exclude: ".*\\.git/.*|.*\\.github/copilot/.*|.*\\.vscode/.*|.*node_modules/.*|.*\\.cache/.*|.*vendor/.*|.*dist/.*"
       run-python: true
       run-shell: true
@@ -36,16 +37,20 @@ jobs:
       run-yaml: true
       run-json: true
       run-javascript: true
-      run-go: false
+      run-go: true
+      run-css: true
+      run-html: true
       run-github-actions: true
       run-security: true
       enable-auto-fix: true
       auto-commit-fixes: true
+      show-detailed-summary: true
     secrets: inherit
 
   # Unified automation for issue management and docs
   unified-automation:
     name: Unified PR Automation
+    needs: super-linter
     uses: jdfalk/ghcommon/.github/workflows/reusable-unified-automation.yml@main
     with:
       operation: "all"
@@ -65,6 +70,7 @@ jobs:
   # Intelligent issue labeling for PRs
   intelligent-labeling:
     name: Intelligent Labeling
+    needs: super-linter
     uses: jdfalk/ghcommon/.github/workflows/reusable-intelligent-issue-labeling.yml@main
     with:
       dry_run: false
@@ -74,6 +80,7 @@ jobs:
   # Standard labeler based on file patterns
   standard-labeler:
     name: Standard File-based Labeling
+    needs: super-linter
     uses: jdfalk/ghcommon/.github/workflows/reusable-labeler.yml@main
     with:
       configuration-path: ".github/labeler.yml"
@@ -85,6 +92,7 @@ jobs:
   ai-rebase:
     name: AI Rebase & Conflict Resolution
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.action != 'closed'
+    needs: super-linter
     uses: jdfalk/ghcommon/.github/workflows/reusable-ai-rebase.yml@main
     with:
       base-branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-ci.yml
-# version: 2.0.1
+# version: 2.0.2
 # guid: 7e2b1c4d-5f6a-4b7c-8e9f-0a1b2c3d4e5f
 
 name: Universal CI/CD
@@ -67,15 +67,18 @@ jobs:
     if: inputs.run-lint == true
     uses: ./.github/workflows/reusable-super-linter.yml
     with:
-      validate-all-codebase: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      validate-all-codebase: true
       default-branch: "main"
+      config-file: ".github/super-linter.env"
       enable-auto-fix: true
       auto-commit-fixes: true
+      show-detailed-summary: true
     secrets:
       github-token: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
 
   changes:
     if: inputs.enable-backend-frontend == true
+    needs: super-linter
     runs-on: ubuntu-latest
     # Permissions removed - should be set in calling workflow
     # See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow

--- a/.github/workflows/reusable-unified-automation.yml
+++ b/.github/workflows/reusable-unified-automation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-unified-automation.yml
-# version: 3.4.0
+# version: 3.4.1
 # guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 name: Unified Automation Orchestrator
@@ -107,7 +107,7 @@ on:
       sl_validate_all_codebase:
         description: "Validate entire codebase with Super Linter"
         required: false
-        default: false
+        default: true
         type: boolean
       sl_default_branch:
         description: "Default branch for Super Linter"
@@ -269,6 +269,7 @@ on:
 jobs:
   issue-management:
     if: ${{ inputs.operation == 'all' || inputs.operation == 'issues' }}
+    needs: super-linter
     uses: ./.github/workflows/reusable-unified-issue-management.yml
     with:
       operations: ${{ inputs.im_operations }}
@@ -287,6 +288,7 @@ jobs:
 
   duplicate-cleanup:
     if: ${{ inputs.operation == 'all' || inputs.operation == 'issues' || inputs.operation == 'duplicates' }}
+    needs: super-linter
     uses: ./.github/workflows/reusable-unified-issue-management.yml
     with:
       operations: "close-duplicates"
@@ -300,6 +302,7 @@ jobs:
 
   docs-update:
     if: ${{ inputs.operation == 'all' || inputs.operation == 'docs' }}
+    needs: super-linter
     uses: ./.github/workflows/reusable-docs-update.yml
     with:
       updates-directory: ${{ inputs.docs_updates_directory }}
@@ -313,7 +316,6 @@ jobs:
       github-token: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
 
   super-linter:
-    if: ${{ inputs.operation == 'all' || inputs.operation == 'lint' }}
     uses: ./.github/workflows/reusable-super-linter.yml
     with:
       validate-all-codebase: ${{ inputs.sl_validate_all_codebase }}
@@ -334,6 +336,7 @@ jobs:
 
   intelligent-labeling:
     if: ${{ inputs.operation == 'all' || inputs.operation == 'intelligent-labeling' }}
+    needs: super-linter
     uses: ./.github/workflows/reusable-intelligent-issue-labeling.yml
     with:
       enabled: ${{ inputs.il_enabled }}
@@ -351,6 +354,7 @@ jobs:
   intelligent-labeling-post-processing:
     if: ${{ inputs.operation == 'all' }}
     needs:
+      - super-linter
       - issue-management
       - docs-update
     uses: ./.github/workflows/reusable-intelligent-issue-labeling.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure Super Linter auto-fixes issues, pushes commits, runs before other jobs, and validates entire codebase
+
 ### Added
 
 - Added concise output mode to Super Linter workflow (default behavior)


### PR DESCRIPTION
## Summary
- run Super Linter before other jobs and allow auto-fixes to push changes
- validate entire repo via Super Linter config and workflows
- document Super Linter workflow improvements in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'inquirer')*

------
https://chatgpt.com/codex/tasks/task_e_6893e8e566d8832183dec10eab356ac0