### PR TITLE
feat: add Codex job submission helper script

### DIFF
--- a/.github/doc-updates/e5e77102-2270-4f6c-8c17-0769731f0a35.json
+++ b/.github/doc-updates/e5e77102-2270-4f6c-8c17-0769731f0a35.json
@@ -1,0 +1,20 @@
+{
+  "file": "CHANGELOG.md",
+  "mode": "changelog-entry",
+  "content": "### Added\n\n- Add script to submit codex jobs",
+  "guid": "e5e77102-2270-4f6c-8c17-0769731f0a35",
+  "created_at": "2025-08-10T23:50:39Z",
+  "processed_at": null,
+  "failed_at": null,
+  "sequence": 0,
+  "parent_guid": null,
+  "options": {
+    "section": null,
+    "after": null,
+    "before": null,
+    "task_id": null,
+    "badge_name": null,
+    "priority": null,
+    "category": null
+  }
+}

--- a/scripts/submit_codex_jobs.py
+++ b/scripts/submit_codex_jobs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# file: scripts/submit_codex_jobs.py
+# version: 1.0.0
+# guid: 9c1d77e9-84a6-4b9b-9e02-d8f6c5bfa519
+"""Submit codex jobs described in a JSON file.
+
+Each job object must include:
+- uuid: unique job identifier
+- repo: repository in owner/name form
+- instructions: text instructions for codex
+- priority: job priority (passed through)
+- repeat (optional): if true, submit even if uuid was submitted before
+
+The script maintains a local ledger of submitted UUIDs in
+``.codex_submitted_jobs.json`` to prevent accidental duplicates.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+LEDGER_PATH = Path(".codex_submitted_jobs.json")
+
+def load_ledger() -> Set[str]:
+    """Load the set of previously submitted job UUIDs."""
+    if LEDGER_PATH.exists():
+        with LEDGER_PATH.open("r", encoding="utf-8") as handle:
+            return set(json.load(handle))
+    return set()
+
+def save_ledger(ledger: Set[str]) -> None:
+    """Persist the ledger of submitted job UUIDs."""
+    with LEDGER_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(sorted(ledger), handle, indent=2)
+
+def submit_job(job: Dict[str, Any]) -> None:
+    """Submit a single job to the codex CLI."""
+    repo = job["repo"]
+    instructions = job["instructions"]
+    priority = str(job.get("priority", "normal"))
+    job_id = job["uuid"]
+    cmd = [
+        "codex",
+        "submit",
+        "--repo",
+        repo,
+        "--instructions",
+        instructions,
+        "--priority",
+        priority,
+        "--uuid",
+        job_id,
+    ]
+    subprocess.run(cmd, check=True)
+
+def process_jobs(jobs: List[Dict[str, Any]], ledger: Set[str]) -> None:
+    """Process and submit all jobs."""
+    for job in jobs:
+        job_id = job["uuid"]
+        repeat = bool(job.get("repeat", False))
+        if job_id in ledger and not repeat:
+            print(f"Skipping {job_id}: already submitted", file=sys.stderr)
+            continue
+        submit_job(job)
+        ledger.add(job_id)
+
+def main() -> int:
+    """Program entry point."""
+    parser = argparse.ArgumentParser(
+        description="Submit codex jobs from a JSON file."
+    )
+    parser.add_argument("path", type=Path, help="Path to JSON job file.")
+    args = parser.parse_args()
+
+    with args.path.open("r", encoding="utf-8") as handle:
+        jobs: List[Dict[str, Any]] = json.load(handle)
+
+    ledger = load_ledger()
+    process_jobs(jobs, ledger)
+    save_ledger(ledger)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add submit_codex_jobs script to send Codex jobs from JSON files
- record changelog entry for the new helper

## Testing
- `python -m py_compile scripts/submit_codex_jobs.py`
- `./scripts/create-issue-update.sh create "Add script to submit codex jobs" "Implement helper to submit codex jobs from JSON files with UUID-based deduplication" "codex,enhancement"` *(failed: /tmp/create-issue-update-library.sh: line 10: local: can only be used in a function)*


------
https://chatgpt.com/codex/tasks/task_e_68992e8fadc4832192de1a984a72baa9