### PR TITLE
feat: add bootstrap-repo skill

### DIFF
--- a/.claude/skills/bootstrap-repo/SKILL.md
+++ b/.claude/skills/bootstrap-repo/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: bootstrap-repo
+description: Create a new GitHub repo or apply ghcommon house standards to an existing one. Use when the user says "create a new repo", "bootstrap a repo", "set up a new repo to our standards", "apply our standards to repo X", "make this repo compliant", "new action/library/service repo", or wants merge settings, branch protection, labels, dependabot, and instruction files configured in one shot. Wraps gh repo create, applies repo-level settings (rebase-only, auto-merge, no delete) and branch protection on main, runs ghcommon's label and instruction-file sync scripts, and seeds flavor-specific overlay files.
+---
+
+# bootstrap-repo
+
+Apply the full jdfalk/ghcommon house standard to a repo: settings, branch
+protection, labels, dependabot, instruction files, flavor overlay.
+
+## When to use
+
+- Creating a brand-new repo (`--mode create`)
+- Bringing an existing repo into compliance (`--mode adopt`)
+- Re-running for idempotency / drift correction
+
+## How it works
+
+The skill is a thin wrapper. The actual work is in `scripts/bootstrap_repo.sh`,
+which orchestrates:
+
+1. `gh repo create` (create mode) or `gh repo view` (adopt mode)
+2. `apply_repo_settings.sh` — `PATCH /repos/:o/:r` with merge/visibility settings
+3. `ghcommon/scripts/sync-repo-setup.py` — copies instructions, dependabot, etc
+4. `ghcommon/scripts/sync-github-labels.py` — applies all labels from `labels.json`
+5. Flavor-specific overlay (action.yml, CHANGELOG.md, Dockerfile)
+6. Seed `.github/repository-config.yml` with `repository.type: <flavor>`
+7. Initial bootstrap commit + push to `main`
+8. `apply_branch_protection.sh` — `PUT /repos/:o/:r/branches/main/protection`
+9. `verify_bootstrap.sh` — read-back diff against expected state
+
+Steps 2 and 8 are split because branch protection requires `main` to exist.
+
+## Decision tree
+
+**Pick the mode.**
+
+- New repo doesn't exist yet → `--mode create`
+- Repo already exists → `--mode adopt`
+
+**Pick the flavor.** See `references/flavors.md` for full file lists.
+
+- Building a GitHub Action → `--flavor action`
+- Building a reusable library/SDK/package → `--flavor library`
+- Building a deployable service or app → `--flavor service`
+
+## Usage
+
+```bash
+# Create a new private library repo
+.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh \
+    --flavor library --mode create --name my-new-thing
+
+# Adopt an existing service repo
+.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh \
+    --flavor service --mode adopt --name existing-service
+
+# Common flags
+#   --owner OWNER         (default: jdfalk)
+#   --private | --public  (default: --private; create mode only)
+#   --ghcommon PATH       (default: ~/repos/github.com/jdfalk/ghcommon)
+#   --repo-path PATH      (skip clone, use this checkout)
+#   --skip-protection     (don't apply branch protection)
+#   --skip-labels         (don't sync labels)
+```
+
+## Verification
+
+After running, `verify_bootstrap.sh` runs automatically and exits non-zero on drift.
+Standalone use:
+
+```bash
+.claude/skills/bootstrap-repo/scripts/verify_bootstrap.sh \
+    --owner jdfalk --repo my-thing --flavor library \
+    --repo-path ~/repos/github.com/jdfalk/my-thing
+```
+
+## What this skill does NOT do
+
+- **Secrets** — does not seed `CI_APP_ID` or any other secret. Run
+  `ghcommon/scripts/setup-ci-app.sh` after bootstrap. Tracked: ghcommon issue #264.
+- **Default branch rename** — assumes `main`; manual fix needed for `master` repos.
+- **Create org/personal templates** — uses `jdfalk/jft-<flavor>-template` if it
+  exists; falls back to empty. The library and service templates don't exist yet.
+- **Modify existing files** — `sync-repo-setup.py` is version-aware and won't
+  clobber locally-modified files.
+
+## References
+
+- `references/repo-settings.md` — every repo-level setting and why
+- `references/branch-protection.md` — protection ruleset and the matrix-job caveat
+- `references/flavors.md` — per-flavor file inventory

--- a/.claude/skills/bootstrap-repo/references/branch-protection.md
+++ b/.claude/skills/bootstrap-repo/references/branch-protection.md
@@ -1,0 +1,152 @@
+# Branch Protection — source of truth
+
+This document specifies the protection ruleset applied to `main` by the bootstrap-repo
+skill. The script `apply_branch_protection.sh` mirrors this exactly.
+
+## Endpoint
+
+```
+PUT /repos/{owner}/{repo}/branches/main/protection
+```
+
+Via `gh`:
+
+```bash
+gh api -X PUT "repos/${OWNER}/${REPO}/branches/main/protection" --input -
+```
+
+This endpoint requires admin permission on the repo.
+
+## Payload
+
+`<CONTEXTS>` is a JSON array of status check names produced by
+`discover_status_checks.py` against the repo's `.github/workflows/` directory.
+If empty, `required_status_checks` becomes `null` (no checks required).
+
+```json
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": <CONTEXTS>
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+```
+
+## Per-field rationale
+
+### `required_status_checks`
+
+| Subfield   | Value          | Why                                                                                                                         |
+| ---------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `strict`   | `true`         | Branches must be up-to-date with `main` before merge — combined with `allow_update_branch: true`, this is one button click. |
+| `contexts` | autodiscovered | See `discover_status_checks.py`. Contexts are the `jobs.<id>` keys from any workflow that triggers on `pull_request`.       |
+
+### `enforce_admins`: `false`
+
+You're the solo owner. Hotfix-on-main during incidents is more important than ceremonial equality. Flip to `true` when a team forms.
+
+### `required_pull_request_reviews`
+
+| Subfield                          | Value   | Why                                                                                                        |
+| --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `required_approving_review_count` | `0`     | Solo maintainer; no human reviewer to wait on. CI is the gate, not approval.                               |
+| `dismiss_stale_reviews`           | `true`  | Pushing new commits invalidates prior approvals. Defense against merging a different PR than was reviewed. |
+| `require_code_owner_reviews`      | `false` | No CODEOWNERS-based gating; with 0 required reviews this is moot anyway.                                   |
+| `require_last_push_approval`      | `false` | Same reasoning — 0 required reviews.                                                                       |
+
+### `required_linear_history`: `true`
+
+Belt-and-suspenders with `allow_rebase_merge: true` / `allow_merge_commit: false`. Even if repo settings drift, the branch protection enforces no merge commits.
+
+### `allow_force_pushes` / `allow_deletions`: both `false`
+
+User policy: disallow all delete. Force-push to `main` is never the right answer; revert is.
+
+### `required_conversation_resolution`: `true`
+
+PR review threads must be resolved before merge. Forces closure on "I'll fix that later" comments. Solo workflow trade-off: one resolve-all click per PR.
+
+### `lock_branch`: `false`
+
+Locking would prevent direct pushes to `main`. With `enforce_admins: false`, you can push directly when needed; locking would override that.
+
+### `restrictions`: `null`
+
+No user/team push restrictions. The protection itself (PR required + status checks) provides the gate.
+
+### `block_creations`: `false`
+
+Ref creation under `main` is allowed (unused for the default branch but required field).
+
+### `allow_fork_syncing`: `true`
+
+Allow forks to sync from upstream — non-controversial; default-on for public repos.
+
+## Status check discovery
+
+The `contexts` array is built by `discover_status_checks.py` with this logic:
+
+1. Glob `.github/workflows/*.yml` and `*.yaml`.
+2. For each workflow, parse YAML.
+3. Filter to workflows whose `on:` block contains `pull_request` (as key, list element, or `pull_request_target`).
+4. Collect `jobs.<id>` keys (the keys, not the `name:` values).
+5. Deduplicate, sort.
+
+### Matrix-job caveat
+
+A workflow like:
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+```
+
+produces _check names_ like `build (ubuntu-latest)` and `build (macos-latest)`. The
+discovered context is `build` (the job ID), which won't match either.
+
+Trade-off accepted: the matrix checks still run on every PR and are visible in the UI;
+they just aren't formally required. `strict: true` ensures the branch is up-to-date,
+so any failure that would block in a non-matrix job will still be visible. Making
+matrix checks formally required would require expanding the matrix in the protection
+config, which would make every matrix change a two-PR affair.
+
+## Edge cases
+
+### Repo has zero workflows
+
+`contexts` is `[]`. `required_status_checks` becomes `null` in the payload (the API
+distinguishes "no required checks" from "required checks: empty list"). `apply_branch_protection.sh`
+handles this transformation.
+
+### Default branch isn't `main`
+
+Out of scope for this skill. The skill assumes `main`. Adopting a repo with `master`
+or another default branch requires renaming the default branch first (manual step).
+
+### `main` doesn't exist yet
+
+Branch protection cannot be applied to a non-existent branch. `bootstrap_repo.sh` ensures
+at least one commit exists on `main` before this step runs (initial sync commit).
+
+## Idempotency
+
+`PUT` replaces the entire protection ruleset. Re-running with the same payload yields
+the same state. `verify_bootstrap.sh` performs a `GET` and structural diff to confirm.

--- a/.claude/skills/bootstrap-repo/references/flavors.md
+++ b/.claude/skills/bootstrap-repo/references/flavors.md
@@ -1,0 +1,81 @@
+# Repo Flavors
+
+Three flavors are supported. The flavor selects which overlay files `bootstrap_repo.sh`
+seeds and which template repo `gh repo create --template` uses (when present).
+
+The fuller per-flavor file inventory lives in `docs/standards/{flavor}-repo.md` once
+ghcommon issue #265 lands. Until then, this file is the working spec.
+
+## action
+
+GitHub Actions repo (composite, JS, or Docker action).
+
+**Overlay files seeded if missing**
+
+- `action.yml` — composite stub
+- `TODO.md` — empty `# TODO` header
+
+**Template repo**: `jdfalk/jft-github-actions` (exists; verified template flag set)
+
+**Notable required files** (from `ACTION_REPO_STANDARDS.md`):
+
+- `action.yml`, `README.md`, `CHANGELOG.md`, `TODO.md`, `ruff.toml`
+- `.pre-commit-config.yaml`, `.yamllint`
+- `.github/dependabot.yml`, `.github/copilot-instructions.md`
+- For Docker actions: `Dockerfile`, `.github/workflows/publish-docker.yml`
+
+## library
+
+Reusable library (Go module, Rust crate, Python package, npm package, etc).
+
+**Overlay files seeded if missing**
+
+- `CHANGELOG.md` — Keep-a-Changelog template
+
+**Template repo**: `jdfalk/jft-library-template` (does not yet exist; falls back to empty)
+
+**Notable required files**
+
+- `README.md` with usage section, `CHANGELOG.md`, `LICENSE`
+- Language-appropriate manifest (`go.mod`, `Cargo.toml`, `pyproject.toml`, `package.json`)
+- `.github/dependabot.yml`, `.github/copilot-instructions.md`, `.github/instructions/`
+
+**Public API surface**: any breaking change requires a CHANGELOG entry under
+`## [Unreleased]` before the merge.
+
+## service
+
+Deployable application or service.
+
+**Overlay files seeded if missing**
+
+- `Dockerfile` — `FROM scratch` placeholder
+
+**Template repo**: `jdfalk/jft-service-template` (does not yet exist; falls back to empty)
+
+**Notable required files**
+
+- `README.md` with **Deployment** section, `LICENSE`
+- `Dockerfile`
+- `.github/workflows/publish-docker.yml` (recommended)
+- `.github/dependabot.yml`, `.github/copilot-instructions.md`, `.github/instructions/`
+
+## Common to all flavors
+
+These come from `ghcommon/scripts/sync-repo-setup.py`, regardless of flavor:
+
+- `.github/instructions/*.instructions.md` — language-specific coding standards
+- `.github/copilot-instructions.md` — AI agent context
+- `.github/AGENTS.md` and related AI files
+- `.github/dependabot.yml` — language-aware dependabot config
+- `.github/repository-config.yml` — seeded with `repository.type: <flavor>`
+
+Repo settings and branch protection are flavor-independent.
+
+## Adding a new flavor
+
+1. Decide on overlay files in `bootstrap_repo.sh`'s `case "${FLAVOR}"` block.
+2. Add it to `--flavor` validation in `bootstrap_repo.sh`.
+3. Document its file list in `docs/standards/<flavor>-repo.md`.
+4. (Optional) create `jdfalk/jft-<flavor>-template` and flip `isTemplate: true`.
+5. Add to this doc.

--- a/.claude/skills/bootstrap-repo/references/repo-settings.md
+++ b/.claude/skills/bootstrap-repo/references/repo-settings.md
@@ -1,0 +1,66 @@
+# Repository Settings — source of truth
+
+This document is the canonical specification for repository-level settings applied
+by the bootstrap-repo skill. The script `apply_repo_settings.sh` mirrors this exactly.
+If they ever disagree, this doc wins.
+
+## Endpoint
+
+```
+PATCH /repos/{owner}/{repo}
+```
+
+Via `gh`:
+
+```bash
+gh api -X PATCH "repos/${OWNER}/${REPO}" --input -
+```
+
+## Payload
+
+```json
+{
+  "allow_merge_commit": false,
+  "allow_squash_merge": false,
+  "allow_rebase_merge": true,
+  "allow_auto_merge": true,
+  "delete_branch_on_merge": false,
+  "allow_update_branch": true,
+  "has_issues": true,
+  "has_projects": false,
+  "has_wiki": false,
+  "web_commit_signoff_required": false
+}
+```
+
+## Per-field rationale
+
+| Field                         | Value   | Why                                                                                                                                                    |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `allow_merge_commit`          | `false` | Merge commits clutter history with non-linear topology; rebase-only keeps `git log` readable.                                                          |
+| `allow_squash_merge`          | `false` | Squash merges discard the in-PR commit history that `git bisect` and reviewers benefit from. Conventional commits within a PR are first-class history. |
+| `allow_rebase_merge`          | `true`  | Linear history. The only allowed merge style.                                                                                                          |
+| `allow_auto_merge`            | `true`  | PRs can be marked auto-merge once required checks pass; reduces context-switching.                                                                     |
+| `delete_branch_on_merge`      | `false` | User policy: disallow all delete. Branches are kept post-merge so old refs resolve.                                                                    |
+| `allow_update_branch`         | `true`  | The "Update branch" button on PRs; keeps branches in sync with `main` without local pulls.                                                             |
+| `has_issues`                  | `true`  | Used by dependabot, labeler workflows, and AI agent issue creation flows.                                                                              |
+| `has_projects`                | `false` | Repo-level Projects (classic) are deprecated UX; org-level Projects supersede.                                                                         |
+| `has_wiki`                    | `false` | Wikis are not versioned with code, not searchable via `grep`, and tend to rot. Documentation lives in-repo.                                            |
+| `web_commit_signoff_required` | `false` | DCO sign-off enforcement breaks GitHub web edits and AI bot commits (Claude, Copilot). Identity is already assured by gh CLI auth and PR review.       |
+
+## Settings deliberately not in payload
+
+These exist on the GitHub API but are intentionally not set by this skill:
+
+- `description`, `homepage`, `topics` — content-level; set per-repo by humans.
+- `private` — set at create time, not bootstrap time. Adoption mode never changes visibility.
+- `archived` — never auto-toggled; user-initiated only.
+- `default_branch` — left as `main` (default). Renaming the default branch breaks too much downstream tooling to be done implicitly.
+- `security_and_analysis.*` — set via separate org-level policy; skill doesn't override.
+
+## Idempotency
+
+`PATCH` is idempotent. Re-running with the same payload is a no-op from the user's
+perspective; the API returns the current state regardless of whether anything changed.
+The `verify_bootstrap.sh` script GETs the same fields and diffs against this payload
+to confirm.

--- a/.claude/skills/bootstrap-repo/scripts/apply_branch_protection.sh
+++ b/.claude/skills/bootstrap-repo/scripts/apply_branch_protection.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Apply branch protection on `main` for OWNER/REPO via gh api PUT.
+# See references/branch-protection.md for the canonical payload and rationale.
+#
+# Status check contexts are autodiscovered from .github/workflows/ in the
+# repo's local checkout. If WORKFLOWS_DIR is unset, defaults to
+# "${REPO_PATH}/.github/workflows" where REPO_PATH is the third arg.
+#
+# Usage:
+#   apply_branch_protection.sh <owner> <repo> <repo_path>
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <owner> <repo> <repo_path>" >&2
+  exit 2
+fi
+
+OWNER="$1"
+REPO="$2"
+REPO_PATH="$3"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOWS_DIR="${WORKFLOWS_DIR:-${REPO_PATH}/.github/workflows}"
+
+# Discover status check contexts (job IDs from PR-triggering workflows).
+if [[ -d ${WORKFLOWS_DIR} ]]; then
+  mapfile -t CONTEXTS < <(python3 "${SCRIPT_DIR}/discover_status_checks.py" "${WORKFLOWS_DIR}")
+else
+  CONTEXTS=()
+fi
+
+# Build required_status_checks JSON: null if no contexts, object otherwise.
+if [[ ${#CONTEXTS[@]} -eq 0 ]]; then
+  REQUIRED_CHECKS_JSON="null"
+  echo "→ No PR-triggering workflows found; required_status_checks=null"
+else
+  CONTEXTS_JSON=$(printf '%s\n' "${CONTEXTS[@]}" | jq -R . | jq -s .)
+  REQUIRED_CHECKS_JSON=$(jq -n --argjson c "${CONTEXTS_JSON}" \
+    '{strict: true, contexts: $c}')
+  echo "→ Discovered ${#CONTEXTS[@]} required check(s): ${CONTEXTS[*]}"
+fi
+
+PAYLOAD=$(jq -n --argjson rsc "${REQUIRED_CHECKS_JSON}" '{
+    required_status_checks: $rsc,
+    enforce_admins: false,
+    required_pull_request_reviews: {
+        dismiss_stale_reviews: true,
+        require_code_owner_reviews: false,
+        required_approving_review_count: 0,
+        require_last_push_approval: false
+    },
+    restrictions: null,
+    required_linear_history: true,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: false,
+    required_conversation_resolution: true,
+    lock_branch: false,
+    allow_fork_syncing: true
+}')
+
+echo "→ Applying branch protection on ${OWNER}/${REPO}:main"
+echo "${PAYLOAD}" | gh api -X PUT "repos/${OWNER}/${REPO}/branches/main/protection" --input - >/dev/null
+echo "✓ Branch protection applied"

--- a/.claude/skills/bootstrap-repo/scripts/apply_repo_settings.sh
+++ b/.claude/skills/bootstrap-repo/scripts/apply_repo_settings.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Apply repository-level settings to OWNER/REPO via gh api PATCH.
+# See references/repo-settings.md for the canonical payload and rationale.
+#
+# Usage:
+#   apply_repo_settings.sh <owner> <repo>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <owner> <repo>" >&2
+  exit 2
+fi
+
+OWNER="$1"
+REPO="$2"
+
+PAYLOAD=$(
+  cat <<'JSON'
+{
+  "allow_merge_commit": false,
+  "allow_squash_merge": false,
+  "allow_rebase_merge": true,
+  "allow_auto_merge": true,
+  "delete_branch_on_merge": false,
+  "allow_update_branch": true,
+  "has_issues": true,
+  "has_projects": false,
+  "has_wiki": false,
+  "web_commit_signoff_required": false
+}
+JSON
+)
+
+echo "→ Applying repo settings to ${OWNER}/${REPO}"
+echo "${PAYLOAD}" | gh api -X PATCH "repos/${OWNER}/${REPO}" --input - >/dev/null
+echo "✓ Repo settings applied"

--- a/.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh
+++ b/.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Bootstrap a GitHub repository to ghcommon standards.
+#
+# Modes:
+#   create — gh repo create + apply standards from empty
+#   adopt  — apply standards to an existing repo
+#
+# Flavors: action | library | service
+#
+# Usage:
+#   bootstrap_repo.sh --flavor {action|library|service} \
+#                     --mode {create|adopt} \
+#                     --name REPO \
+#                     [--owner jdfalk] [--private|--public] \
+#                     [--ghcommon PATH] [--repo-path PATH] \
+#                     [--skip-protection] [--skip-labels]
+#
+# See references/repo-settings.md and references/branch-protection.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------- argument parsing ----------
+
+FLAVOR=""
+MODE=""
+OWNER="jdfalk"
+NAME=""
+VISIBILITY="--private"
+GHCOMMON=""
+REPO_PATH=""
+SKIP_PROTECTION=0
+SKIP_LABELS=0
+
+usage() {
+  sed -n '2,18p' "$0" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --flavor)
+    FLAVOR="$2"
+    shift 2
+    ;;
+  --mode)
+    MODE="$2"
+    shift 2
+    ;;
+  --owner)
+    OWNER="$2"
+    shift 2
+    ;;
+  --name)
+    NAME="$2"
+    shift 2
+    ;;
+  --private)
+    VISIBILITY="--private"
+    shift
+    ;;
+  --public)
+    VISIBILITY="--public"
+    shift
+    ;;
+  --ghcommon)
+    GHCOMMON="$2"
+    shift 2
+    ;;
+  --repo-path)
+    REPO_PATH="$2"
+    shift 2
+    ;;
+  --skip-protection)
+    SKIP_PROTECTION=1
+    shift
+    ;;
+  --skip-labels)
+    SKIP_LABELS=1
+    shift
+    ;;
+  -h | --help) usage ;;
+  *)
+    echo "unknown arg: $1" >&2
+    usage
+    ;;
+  esac
+done
+
+[[ -z ${FLAVOR} ]] && {
+  echo "error: --flavor required" >&2
+  exit 2
+}
+[[ -z ${MODE} ]] && {
+  echo "error: --mode required" >&2
+  exit 2
+}
+[[ -z ${NAME} ]] && {
+  echo "error: --name required" >&2
+  exit 2
+}
+
+case "${FLAVOR}" in action | library | service) ;; *)
+  echo "error: --flavor must be action, library, or service" >&2
+  exit 2
+  ;;
+esac
+case "${MODE}" in create | adopt) ;; *)
+  echo "error: --mode must be create or adopt" >&2
+  exit 2
+  ;;
+esac
+
+# ---------- resolve ghcommon path ----------
+
+if [[ -z ${GHCOMMON} ]]; then
+  GHCOMMON="${GHCOMMON_PATH:-$HOME/repos/github.com/jdfalk/ghcommon}"
+fi
+if [[ ! -d "${GHCOMMON}/.github/instructions" ]]; then
+  echo "error: ghcommon not found at ${GHCOMMON}" >&2
+  echo "       set --ghcommon PATH or GHCOMMON_PATH env var" >&2
+  exit 1
+fi
+echo "→ Using ghcommon at: ${GHCOMMON}"
+
+# ---------- create or verify repo ----------
+
+if [[ ${MODE} == "create" ]]; then
+  echo "→ Creating ${OWNER}/${NAME} (${VISIBILITY#--})"
+  if gh repo view "${OWNER}/${NAME}" >/dev/null 2>&1; then
+    echo "error: repo already exists; use --mode adopt" >&2
+    exit 1
+  fi
+  # Try template if it exists for this flavor; fall back to empty.
+  TEMPLATE="${OWNER}/jft-${FLAVOR}-template"
+  if gh repo view "${TEMPLATE}" >/dev/null 2>&1; then
+    echo "→ Creating from template ${TEMPLATE}"
+    gh repo create "${OWNER}/${NAME}" "${VISIBILITY}" --template "${TEMPLATE}"
+  else
+    echo "→ Template ${TEMPLATE} not found; creating empty"
+    gh repo create "${OWNER}/${NAME}" "${VISIBILITY}" --add-readme
+  fi
+else
+  if ! gh repo view "${OWNER}/${NAME}" >/dev/null 2>&1; then
+    echo "error: ${OWNER}/${NAME} not found; use --mode create" >&2
+    exit 1
+  fi
+  echo "→ Adopting existing ${OWNER}/${NAME}"
+fi
+
+# ---------- ensure local checkout ----------
+
+if [[ -z ${REPO_PATH} ]]; then
+  REPO_PATH="$(mktemp -d "/tmp/bootstrap-${NAME}.XXXXXX")"
+  echo "→ Cloning into ${REPO_PATH}"
+  gh repo clone "${OWNER}/${NAME}" "${REPO_PATH}" -- --quiet
+  CLEANUP_REPO_PATH=1
+else
+  echo "→ Using local checkout at ${REPO_PATH}"
+  CLEANUP_REPO_PATH=0
+fi
+
+# ---------- apply repo settings ----------
+
+"${SCRIPT_DIR}/apply_repo_settings.sh" "${OWNER}" "${NAME}"
+
+# ---------- sync standard files from ghcommon ----------
+
+echo "→ Syncing instruction/dependabot/AGENTS files from ghcommon"
+SYNC_SCRIPT="${GHCOMMON}/scripts/sync-repo-setup.py"
+if [[ -f ${SYNC_SCRIPT} ]]; then
+  python3 "${SYNC_SCRIPT}" --target "${REPO_PATH}" ||
+    echo "  (sync-repo-setup.py failed; continuing — may need flag adjustment)"
+else
+  echo "  (sync-repo-setup.py not found at ${SYNC_SCRIPT}; skipping)"
+fi
+
+# ---------- sync labels ----------
+
+if [[ ${SKIP_LABELS} -eq 0 ]]; then
+  echo "→ Syncing labels from ghcommon/labels.json"
+  LABEL_SCRIPT="${GHCOMMON}/scripts/sync-github-labels.py"
+  if [[ -f ${LABEL_SCRIPT} ]]; then
+    GH_TOKEN="${GH_TOKEN:-$(gh auth token)}" \
+      python3 "${LABEL_SCRIPT}" --owner "${OWNER}" --repo "${NAME}" \
+      --labels "${GHCOMMON}/labels.json" ||
+      echo "  (sync-github-labels.py failed; continuing)"
+  fi
+fi
+
+# ---------- flavor overlay ----------
+
+echo "→ Applying flavor overlay: ${FLAVOR}"
+case "${FLAVOR}" in
+action)
+  # action.yml stub if missing
+  if [[ ! -f "${REPO_PATH}/action.yml" ]]; then
+    cat >"${REPO_PATH}/action.yml" <<EOF
+name: '${NAME}'
+description: 'TODO: describe this action'
+runs:
+  using: 'composite'
+  steps:
+    - run: echo "TODO: implement ${NAME}"
+      shell: bash
+EOF
+  fi
+  [[ -f "${REPO_PATH}/TODO.md" ]] || echo "# TODO" >"${REPO_PATH}/TODO.md"
+  ;;
+library)
+  if [[ ! -f "${REPO_PATH}/CHANGELOG.md" ]]; then
+    cat >"${REPO_PATH}/CHANGELOG.md" <<'EOF'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+EOF
+  fi
+  ;;
+service)
+  if [[ ! -f "${REPO_PATH}/Dockerfile" ]]; then
+    cat >"${REPO_PATH}/Dockerfile" <<'EOF'
+# TODO: choose a base image
+FROM scratch
+# TODO: COPY artifacts and set ENTRYPOINT
+EOF
+  fi
+  ;;
+esac
+
+# ---------- seed repository-config.yml ----------
+
+CONFIG_FILE="${REPO_PATH}/.github/repository-config.yml"
+if [[ ! -f ${CONFIG_FILE} ]]; then
+  mkdir -p "$(dirname "${CONFIG_FILE}")"
+  cat >"${CONFIG_FILE}" <<EOF
+# file: .github/repository-config.yml
+# Seeded by bootstrap-repo skill on $(date -u +%Y-%m-%d)
+
+repository:
+  name: ${NAME}
+  type: ${FLAVOR}
+  primary_language: auto
+  description: ''
+EOF
+fi
+
+# ---------- commit & push ----------
+
+cd "${REPO_PATH}"
+if [[ -n "$(git status --porcelain)" ]]; then
+  git add -A
+  git -c user.name="ghcommon-bootstrap" -c user.email="bootstrap@ghcommon.local" \
+    commit -m "chore: bootstrap repo to ghcommon standards (${FLAVOR})"
+  git push origin HEAD:main || git push -u origin HEAD
+  echo "✓ Pushed bootstrap commit"
+else
+  echo "→ No file changes to commit"
+fi
+
+# ---------- apply branch protection (after commit so main exists) ----------
+
+if [[ ${SKIP_PROTECTION} -eq 0 ]]; then
+  "${SCRIPT_DIR}/apply_branch_protection.sh" "${OWNER}" "${NAME}" "${REPO_PATH}"
+else
+  echo "→ Skipping branch protection (--skip-protection)"
+fi
+
+# ---------- verify ----------
+
+"${SCRIPT_DIR}/verify_bootstrap.sh" --owner "${OWNER}" --repo "${NAME}" \
+  --repo-path "${REPO_PATH}" --flavor "${FLAVOR}"
+
+# ---------- next steps ----------
+
+cat <<EOF
+
+✅ Bootstrap complete: ${OWNER}/${NAME}
+
+Next steps (manual):
+  1. Run setup-ci-app.sh in the repo to create/link the GitHub App for releases.
+     (Tracked: future automation in ghcommon issue #264)
+  2. Verify secrets exist: gh secret list -R ${OWNER}/${NAME}
+     Expected (if release workflows used): CI_APP_ID, CI_APP_PRIVATE_KEY
+  3. Review the bootstrap commit and adjust flavor-overlay stubs as needed.
+
+Local checkout: ${REPO_PATH}
+EOF
+
+if [[ ${CLEANUP_REPO_PATH} -eq 1 ]]; then
+  echo "  (Temp checkout will remain at ${REPO_PATH} for review.)"
+fi

--- a/.claude/skills/bootstrap-repo/scripts/discover_status_checks.py
+++ b/.claude/skills/bootstrap-repo/scripts/discover_status_checks.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Discover required-status-check contexts from a repo's workflows directory.
+
+Outputs newline-separated job IDs from any workflow that triggers on
+`pull_request` (or `pull_request_target`). Used by apply_branch_protection.sh
+to populate `required_status_checks.contexts`.
+
+Usage:
+    discover_status_checks.py <workflows_dir>
+
+Example:
+    discover_status_checks.py .github/workflows/
+
+See references/branch-protection.md for the matrix-job caveat.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+PR_TRIGGERS = {"pull_request", "pull_request_target"}
+
+
+def has_pr_trigger(on_block) -> bool:
+    """Return True if a workflow's `on:` block triggers on a PR event."""
+    if isinstance(on_block, str):
+        return on_block in PR_TRIGGERS
+    if isinstance(on_block, list):
+        return any(t in PR_TRIGGERS for t in on_block)
+    if isinstance(on_block, dict):
+        return any(t in PR_TRIGGERS for t in on_block)
+    return False
+
+
+def collect_job_ids(workflows_dir: Path) -> list[str]:
+    """Walk *.yml and *.yaml in workflows_dir, return sorted job IDs."""
+    job_ids: set[str] = set()
+    for path in sorted(workflows_dir.glob("*.y*ml")):
+        try:
+            with path.open() as f:
+                doc = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"warning: skipping {path.name}: {e}", file=sys.stderr)
+            continue
+        if not isinstance(doc, dict):
+            continue
+        # PyYAML parses the bare key `on` as Python True (boolean). Handle both.
+        on_block = doc.get("on", doc.get(True))
+        if not has_pr_trigger(on_block):
+            continue
+        jobs = doc.get("jobs") or {}
+        if isinstance(jobs, dict):
+            job_ids.update(jobs.keys())
+    return sorted(job_ids)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <workflows_dir>", file=sys.stderr)
+        return 2
+    workflows_dir = Path(argv[1])
+    if not workflows_dir.is_dir():
+        print(f"error: not a directory: {workflows_dir}", file=sys.stderr)
+        return 1
+    for jid in collect_job_ids(workflows_dir):
+        print(jid)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/skills/bootstrap-repo/scripts/verify_bootstrap.sh
+++ b/.claude/skills/bootstrap-repo/scripts/verify_bootstrap.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Verify a repository matches ghcommon bootstrap expectations.
+# Reads back repo settings + branch protection via gh api and diffs against
+# the canonical payload from references/repo-settings.md and branch-protection.md.
+#
+# Exits 0 on full match, 1 on any drift, 2 on usage error.
+#
+# Usage:
+#   verify_bootstrap.sh --owner OWNER --repo REPO \
+#                       [--repo-path PATH] [--flavor FLAVOR]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+OWNER=""
+REPO=""
+REPO_PATH=""
+FLAVOR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --owner)
+    OWNER="$2"
+    shift 2
+    ;;
+  --repo)
+    REPO="$2"
+    shift 2
+    ;;
+  --repo-path)
+    REPO_PATH="$2"
+    shift 2
+    ;;
+  --flavor)
+    FLAVOR="$2"
+    shift 2
+    ;;
+  *)
+    echo "unknown arg: $1" >&2
+    exit 2
+    ;;
+  esac
+done
+
+[[ -z ${OWNER} || -z ${REPO} ]] && {
+  echo "usage: $0 --owner OWNER --repo REPO [--repo-path PATH] [--flavor FLAVOR]" >&2
+  exit 2
+}
+
+DRIFT=0
+
+# ---------- repo settings ----------
+
+EXPECTED_SETTINGS=$(
+  cat <<'JSON'
+{
+  "allow_merge_commit": false,
+  "allow_squash_merge": false,
+  "allow_rebase_merge": true,
+  "allow_auto_merge": true,
+  "delete_branch_on_merge": false,
+  "allow_update_branch": true,
+  "has_issues": true,
+  "has_projects": false,
+  "has_wiki": false,
+  "web_commit_signoff_required": false
+}
+JSON
+)
+
+echo "→ Checking repo settings on ${OWNER}/${REPO}"
+ACTUAL=$(gh api "repos/${OWNER}/${REPO}")
+while IFS= read -r key; do
+  expected=$(echo "${EXPECTED_SETTINGS}" | jq -r ".${key}")
+  actual=$(echo "${ACTUAL}" | jq -r ".${key}")
+  if [[ ${expected} != "${actual}" ]]; then
+    echo "  ✗ ${key}: expected=${expected} actual=${actual}"
+    DRIFT=1
+  fi
+done < <(echo "${EXPECTED_SETTINGS}" | jq -r 'keys[]')
+
+if [[ ${DRIFT} -eq 0 ]]; then
+  echo "  ✓ Repo settings match"
+fi
+
+# ---------- branch protection ----------
+
+echo "→ Checking branch protection on ${OWNER}/${REPO}:main"
+PROTECTION=$(gh api "repos/${OWNER}/${REPO}/branches/main/protection" 2>/dev/null || echo "")
+
+if [[ -z ${PROTECTION} ]]; then
+  echo "  ✗ No protection on main"
+  DRIFT=1
+else
+  check() {
+    local path="$1" expected="$2"
+    local actual
+    actual=$(echo "${PROTECTION}" | jq -r "${path}")
+    if [[ ${actual} != "${expected}" ]]; then
+      echo "  ✗ ${path}: expected=${expected} actual=${actual}"
+      DRIFT=1
+    fi
+  }
+  check '.required_status_checks.strict' 'true'
+  check '.enforce_admins.enabled' 'false'
+  check '.required_pull_request_reviews.dismiss_stale_reviews' 'true'
+  check '.required_pull_request_reviews.required_approving_review_count' '0'
+  check '.required_linear_history.enabled' 'true'
+  check '.allow_force_pushes.enabled' 'false'
+  check '.allow_deletions.enabled' 'false'
+  check '.required_conversation_resolution.enabled' 'true'
+
+  # Status check contexts: compare against discover_status_checks output
+  if [[ -n ${REPO_PATH} && -d "${REPO_PATH}/.github/workflows" ]]; then
+    EXPECTED_CONTEXTS=$(python3 "${SCRIPT_DIR}/discover_status_checks.py" \
+      "${REPO_PATH}/.github/workflows" | sort)
+    ACTUAL_CONTEXTS=$(echo "${PROTECTION}" |
+      jq -r '.required_status_checks.contexts[]?' | sort)
+    if [[ ${EXPECTED_CONTEXTS} != "${ACTUAL_CONTEXTS}" ]]; then
+      echo "  ✗ status check contexts drift:"
+      diff <(echo "${EXPECTED_CONTEXTS}") <(echo "${ACTUAL_CONTEXTS}") || true
+      DRIFT=1
+    fi
+  fi
+
+  if [[ ${DRIFT} -eq 0 ]]; then
+    echo "  ✓ Branch protection matches"
+  fi
+fi
+
+# ---------- summary ----------
+
+if [[ ${DRIFT} -eq 0 ]]; then
+  echo ""
+  echo "✅ ${OWNER}/${REPO} is bootstrap-compliant${FLAVOR:+ (${FLAVOR})}"
+  exit 0
+else
+  echo ""
+  echo "❌ ${OWNER}/${REPO} has drift; re-run bootstrap_repo.sh to fix"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `.claude/skills/bootstrap-repo/` — a thin orchestration skill that creates a new GitHub repo (or adopts an existing one) and applies the full ghcommon house standard in one command: settings, branch protection, labels, dependabot, instruction files, flavor overlay.

## Design summary

| Decision | Value |
|---|---|
| Owner default | hardcoded `jdfalk`, override via `--owner` |
| Status check discovery | parse YAML `jobs.<id>` keys from PR-triggering workflows |
| `web_commit_signoff_required` | off |
| `required_conversation_resolution` | on |
| `enforce_admins` | off |
| `has_issues` / `has_wiki` / `has_projects` | on / off / off |
| Merge | rebase-only, auto-merge on, no delete |
| Required approvals | 0 (with `dismiss_stale_reviews: true`) |
| Secrets | manual checklist (deferred to issue #264) |

Reference docs (`references/repo-settings.md`, `references/branch-protection.md`) are the canonical source of truth; scripts mirror them. Drift is caught by `verify_bootstrap.sh`.

## What's in the PR

- `SKILL.md` — thin trigger doc + usage + flavor decision tree
- `scripts/bootstrap_repo.sh` — orchestrator (create/adopt × action/library/service)
- `scripts/apply_repo_settings.sh` — `gh api PATCH /repos/:o/:r`
- `scripts/apply_branch_protection.sh` — `gh api PUT /repos/:o/:r/branches/main/protection`
- `scripts/discover_status_checks.py` — YAML parser → required-check contexts
- `scripts/verify_bootstrap.sh` — read-back diff, idempotency check
- `references/{repo-settings,branch-protection,flavors}.md` — canonical specs

Reuses `ghcommon/scripts/sync-repo-setup.py` and `sync-github-labels.py` rather than duplicating them.

## Cross-references

- ghcommon#264 — future: secret provisioning automation (deferred)
- ghcommon#265 — followup: split `ACTION_REPO_STANDARDS.md` by flavor + audit `labels.json` (deferred; was originally planned as parallel subagent work but blocked by harness gating on Bash)

## Test plan

- [x] `shellcheck` passes on all `.sh` files (enforced via pre-commit)
- [x] `ruff` passes on `discover_status_checks.py`
- [x] `discover_status_checks.py` produces correct job IDs against ghcommon's own workflows (19 jobs surfaced)
- [x] `quick_validate.py` reports skill is valid
- [ ] Live dry-run on `jdfalk/bootstrap-test-DELETE-ME` (private throwaway): adopt mode, verify state, re-run, confirm idempotency, delete. **Pending user authorization** — creates and destroys a real (private) GitHub repo.
- [ ] Apply to one real existing repo (suggest a low-risk one) and confirm settings stick

## Notes for reviewer

- The skill assumes ghcommon is cloned at `~/repos/github.com/jdfalk/ghcommon` (override via `--ghcommon` or `$GHCOMMON_PATH`).
- The skill assumes `main` is the default branch. Adopting a `master`-default repo requires a manual rename first.
- Library and service template repos (`jft-library-template`, `jft-service-template`) don't yet exist — the skill falls back to creating an empty repo. Once the skill stabilizes, run it against two empty repos and flip `isTemplate: true` to bootstrap the templates from the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)