### PR TITLE
fix(bootstrap-repo): mapfile portability for bash 3.2 (macOS)

### DIFF
--- a/.claude/skills/bootstrap-repo/scripts/apply_branch_protection.sh
+++ b/.claude/skills/bootstrap-repo/scripts/apply_branch_protection.sh
@@ -23,10 +23,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKFLOWS_DIR="${WORKFLOWS_DIR:-${REPO_PATH}/.github/workflows}"
 
 # Discover status check contexts (job IDs from PR-triggering workflows).
+# Avoid `mapfile` — macOS ships bash 3.2 which lacks it.
+CONTEXTS=()
 if [[ -d ${WORKFLOWS_DIR} ]]; then
-  mapfile -t CONTEXTS < <(python3 "${SCRIPT_DIR}/discover_status_checks.py" "${WORKFLOWS_DIR}")
-else
-  CONTEXTS=()
+  while IFS= read -r line; do
+    [[ -n ${line} ]] && CONTEXTS+=("${line}")
+  done < <(python3 "${SCRIPT_DIR}/discover_status_checks.py" "${WORKFLOWS_DIR}")
 fi
 
 # Build required_status_checks JSON: null if no contexts, object otherwise.


### PR DESCRIPTION
## Summary

`apply_branch_protection.sh` used `mapfile -t`, a bash 4+ builtin. macOS ships bash 3.2 by default, so the bootstrap fails at the protection step:

```
apply_branch_protection.sh: line 27: mapfile: command not found
```

Replaces with a portable `while IFS= read -r` loop that builds the `CONTEXTS` array incrementally. Same behavior, no bash version dependency.

## How discovered

While running `bootstrap_repo.sh --flavor cli --mode adopt --name magnet-handler` (the first real-world adoption). The earlier `bootstrap-test-DELETE-ME` dry-run had no `pull_request` workflows so the mapfile branch wasn't taken. `magnet-handler` has a `ci` workflow, which is what triggered the discovery code path for the first time.

magnet-handler bootstrap completed end-to-end after manually applying this fix:
- Repo settings ✓
- Sync from ghcommon ✓ (51 files, 11057 insertions)
- Labels ✓ (189/242, rate-limit on remainder)
- CLI flavor overlay ✓ (CHANGELOG.md seeded)
- Bootstrap commit pushed ✓
- Branch protection ✓ (with the fix; 1 required check `ci`)
- Registry updated ✓ (`.github/bootstrapped-repos.json`)
- verify_bootstrap.sh exit 0 ✓

## Test plan

- [x] `shellcheck` passes
- [x] Direct invocation against magnet-handler succeeds with bash 3.2
- [x] No other `mapfile` usages in the skill (grep clean)