### PR TITLE
chore: register magnet-handler bootstrap + gitignore Claude local settings

### DIFF
--- a/.github/bootstrapped-repos.json
+++ b/.github/bootstrapped-repos.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "repos": [
+    {
+      "owner": "jdfalk",
+      "name": "magnet-handler",
+      "flavor": "cli",
+      "mode": "adopt",
+      "first_bootstrapped": "2026-04-25T13:01:32Z",
+      "last_bootstrapped": "2026-04-25T13:01:32Z"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -700,3 +700,6 @@ logs/
 
 # Workflow debugging output (should not be committed)
 scripts/workflow-debug-output/
+
+# Claude Code per-machine local settings — never committed
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- First entry in the bootstrap registry: `jdfalk/magnet-handler` (cli flavor, adopt mode, 2026-04-25). Future bootstraps upsert via `_update_registry.py`; this commit creates the file.
- Gitignore `.claude/settings.local.json` — per-machine Claude Code permission state, not meant to be shared.

## Test plan

- [x] Registry JSON schema valid (matches `_update_registry.py` output)
- [x] `magnet-handler` is bootstrap-compliant (verified via `verify_bootstrap.sh` exit 0)