### PR TITLE
fix(release): pass GH_TOKEN to Publish-to-GitHub-Packages step

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -757,6 +757,12 @@ jobs:
 
       - name: Publish artifacts to GitHub Packages
         env:
+          # publish_to_github_packages.py shells out to `gh release upload`,
+          # which requires GH_TOKEN. Without this the step fails with
+          # "To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
+          # environment variable" and exits 4.
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           PRIMARY_LANGUAGE: ${{ needs.detect-languages.outputs.primary-language || 'unknown' }}
           RELEASE_TAG: ${{ needs.detect-languages.outputs.release-tag }}
           RELEASE_STRATEGY: ${{ needs.detect-languages.outputs.release-branch-strategy }}


### PR DESCRIPTION
## Summary

`publish_to_github_packages.py` shells out to `gh release upload`, which hard-requires `GH_TOKEN` in the environment. Without it, every release caller fails with:

```
To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Error: Process completed with exit code 4.
```

Caught by burndown-runner-image's first publish run today. Fix is to thread `GH_TOKEN: ${{ github.token }}` (and `GITHUB_TOKEN` for belt-and-braces — some scripts in the same step might use it) into the step's `env:` block.

## Test plan

- [ ] Re-trigger the burndown-runner-image build workflow after merge to confirm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)