### PR TITLE
fix(release): replace secrets-in-if with env-bridge guard step

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -311,9 +311,23 @@ jobs:
       # commits touch .github/workflows/ — the default GITHUB_TOKEN
       # can't. Skipped entirely when CI_APP_ID isn't configured so the
       # job doesn't emit a noisy error; falls back to GITHUB_TOKEN.
+      # `if:` cannot reference secrets.* directly in a workflow_call workflow
+      # ("Unrecognized named-value: 'secrets'"). Materialize CI_APP_ID through
+      # env in a guard step, then gate the mint step on that step's output.
+      - name: Check for App credentials
+        id: check-app
+        env:
+          CI_APP_ID: ${{ secrets.CI_APP_ID }}
+        run: |
+          if [ -n "$CI_APP_ID" ]; then
+            echo "have-app=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have-app=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Mint App token for tag push
         id: app-token
-        if: ${{ secrets.CI_APP_ID != '' }}
+        if: steps.check-app.outputs.have-app == 'true'
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.CI_APP_ID }}


### PR DESCRIPTION
## Summary

`if: ${{ secrets.CI_APP_ID != '' }}` is invalid in a reusable (`workflow_call`) workflow — GitHub Actions rejects with:

```
Invalid workflow file: ...
error parsing called workflow
-> 'jdfalk/ghcommon/.github/workflows/reusable-release.yml@<sha>'
: (Line: 316, Col: 13): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.CI_APP_ID != ''
```

Every caller fails to validate (0-second runtime, name shows as the file path instead of `name:`).

Materialize the secret through `env` in a guard step, then gate the Mint step on that step's output. Same observable behavior — skip mint when `CI_APP_ID` is empty — but the if-expression uses `steps.check-app.outputs.*` which IS allowed in callable workflows.

## How this snuck in

Original commit `c46f978` ("skip app-token mint when CI_APP_ID is unset") swapped `continue-on-error: true` for `if: ${{ secrets.CI_APP_ID != '' }}`. `continue-on-error` worked in a reusable; the if expression doesn't.

## Test plan

- [x] Tested locally with actionlint
- [ ] After merge: re-trigger overnight-burndown's prerelease.yml and confirm the run validates and proceeds past load-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)