### PR TITLE
fix(ci): update jdfalk/* action pins to current SHAs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/documentation.yml
-# version: 1.1.0
+# version: 1.1.1
 # guid: docs-automation-workflow-2025
 
 name: Documentation
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate helper documentation
-        uses: jdfalk/docs-generator-action@38757a4566f6075ba56270c33bd1392e5a34f5a1 # v1.1.3
+        uses: jdfalk/docs-generator-action@348ba194a5f4060f07d954cbc0d1f123230c4580 # v1.1.3
         with:
           source-dir: .github/workflows/scripts
           workflows-dir: .github/workflows

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/pr-automation.yml
-# version: 4.5.4
+# version: 4.5.5
 # guid: a7b8c9d0-e1f2-3456-a789-0123456789bc
 # NOTE: This file should be updated in ghcommon repository first, then copied to other repositories.
 # To update: Edit in https://github.com/jdfalk/ghcommon/.github/workflows/pr-automation.yml then copy to other repos
@@ -290,7 +290,7 @@ jobs:
           "
 
       - name: Run intelligent labeling
-        uses: jdfalk/pr-auto-label-action@68583016672fe5a5348c040ab8ed7aa3e678df5b # v1.1.3
+        uses: jdfalk/pr-auto-label-action@54023423d4f61a781402f6c801d3c3b48af7a3c4 # v1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release.yml
-# version: 2.0.0
+# version: 2.0.1
 # guid: 8b4d6c2a-1f5e-4a8b-9c3d-7e2f5a8b1c4d
 
 name: Release
@@ -64,9 +64,9 @@ jobs:
     name: Release
     uses: ./.github/workflows/reusable-release.yml
     with:
-      release-type: ${{ github.event.inputs.release-type || 'auto' }}
-      build-target: ${{ github.event.inputs.build-target || 'all' }}
-      draft: ${{ github.event.inputs.draft || false }}
-      prerelease: ${{ github.event.inputs.prerelease || false }}
-      stable: ${{ github.event.inputs.stable || false }}
+      release-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release-type || 'auto' }}
+      build-target: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-target || 'all' }}
+      draft: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.draft == 'true' || false }}
+      prerelease: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.prerelease == 'true' }}
+      stable: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stable == 'true' || false }}
     secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-ci.yml
-# version: 1.12.0
+# version: 1.12.1
 # guid: reusable-ci-2025-09-24-core-workflow
 
 name: Reusable CI Workflow
@@ -115,14 +115,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Load repository configuration
         id: load
-        uses: jdfalk/load-config-action@f53a2a9d7bc80d26be0f3339188fe84f2feabb38 # v1.1.3
+        uses: jdfalk/load-config-action@482b9f0e631b2325071cd9bf04c8fda4591044b0 # v1.1.3
         with:
           config-file: .github/repository-config.yml
           fail-on-missing: false
 
       - name: Generate language matrices
         id: matrices
-        uses: jdfalk/ci-generate-matrices-action@42c7fbecc88681339d29e1b6400d5fc667681aa1 # v1.1.6
+        uses: jdfalk/ci-generate-matrices-action@96db335687d5263a5f9ca676ba2df8d834465b18 # v1.1.6
         with:
           repository-config: ${{ steps.load.outputs.config }}
           fallback-go-version: ${{ inputs.go-version }}
@@ -305,7 +305,7 @@ jobs:
     name: Cache npm (Workflow Scripts)
     needs: detect-changes
     if: needs.detect-changes.outputs.workflows-scripts == 'true' || github.event_name == 'workflow_dispatch'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@06d833f53520ec04669cc573165ef0d1d694a373 # v1.10.3+
+    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@cf2068996e1ecf737a6e2c269a9429f0764e76cd # v1.10.3+
     with:
       language: 'node'
       cache-prefix: 'npm-workflow-scripts'
@@ -389,7 +389,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate protobuf
-        uses: jdfalk/gha-release-protobuf@04bad49f96a51ec7602024d8c6dd44fde811426d # v1.0.1
+        uses: jdfalk/gha-release-protobuf@afcb06673c957919bf28b9661b58038931588ea5 # v1.0.1
 
   # Language-specific build and test jobs
   go-ci:
@@ -447,13 +447,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y $PACKAGES
 
       - name: Build Go project
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: go-setup
 
       - name: Test Go project
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: go-test
           coverage-threshold: ${{ inputs.coverage-threshold || needs.load-config.outputs.coverage-threshold }}
@@ -519,7 +519,7 @@ jobs:
           echo "GHCOMMON_SCRIPTS_DIR=$PWD/ghcommon-workflow-scripts/.github/workflows/scripts" >> "$GITHUB_ENV"
 
       - name: Install Python dependencies
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: python-install
 
@@ -530,7 +530,7 @@ jobs:
 
       - name: Test Python code
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: python-run-tests
 
@@ -593,24 +593,24 @@ jobs:
 
       - name: Format Rust code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: rust-format
 
       - name: Lint Rust code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: rust-clippy
 
       - name: Build Rust project
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: rust-build
 
       - name: Test Rust project
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: rust-test
 
@@ -619,7 +619,7 @@ jobs:
     name: Cache npm (Frontend)
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend-files == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@06d833f53520ec04669cc573165ef0d1d694a373 # v1.10.3+
+    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@cf2068996e1ecf737a6e2c269a9429f0764e76cd # v1.10.3+
     with:
       language: 'node'
       cache-prefix: 'npm-frontend'
@@ -644,7 +644,7 @@ jobs:
 
       - name: Get frontend working directory
         id: frontend-dir
-        uses: jdfalk/get-frontend-config-action@3d728dd5c1f057dfdc97fc6eb3ca1e8fe8ba3a1b # v1.1.3
+        uses: jdfalk/get-frontend-config-action@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
         with:
           repository-config: ${{ env.REPOSITORY_CONFIG }}
 
@@ -681,14 +681,14 @@ jobs:
       # No additional cache setup needed here.
 
       - name: Install dependencies
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: frontend-install
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
 
       - name: Lint frontend code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -697,7 +697,7 @@ jobs:
           frontend-failure-message: '❌ Linting failed or not configured'
 
       - name: Build frontend
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -707,7 +707,7 @@ jobs:
 
       - name: Test frontend
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -730,7 +730,7 @@ jobs:
 
       - name: Run E2E tests
         if: ${{ !inputs.skip-tests && !inputs.skip-e2e-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -820,7 +820,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Generate summary
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: generate-ci-summary
         env:
@@ -835,7 +835,7 @@ jobs:
           JOB_DOCS: skipped
 
       - name: Check overall status
-        uses: jdfalk/ci-workflow-helpers-action@56a885638b0c9745b64250ca06d0f6218fa9f63d # v1.1.4
+        uses: jdfalk/ci-workflow-helpers-action@e64725c836a7ea33925f02a86d673d898ce4a713 # v1.1.4
         with:
           command: check-ci-status
         env:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.13.0
+# version: 2.13.1
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Load repository configuration
         id: load-config
-        uses: jdfalk/load-config-action@f53a2a9d7bc80d26be0f3339188fe84f2feabb38 # v1.1.3
+        uses: jdfalk/load-config-action@482b9f0e631b2325071cd9bf04c8fda4591044b0 # v1.1.3
         with:
           config-file: .github/repository-config.yml
           fail-on-missing: false
@@ -174,7 +174,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Detect project languages and generate matrices
         id: detect
-        uses: jdfalk/detect-languages-action@c10aa6cf6cf58ed0ecaa41aa3b7e0afaf4ed9c8b # v1.1.5
+        uses: jdfalk/detect-languages-action@e8b6061298420be7fd087ea148587fa61176137b # v1.1.5
         with:
           skip-detection: ${{ inputs.skip-language-detection }}
           build-target: ${{ inputs.build-target || 'all' }}
@@ -289,7 +289,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate protobuf
-        uses: jdfalk/gha-release-protobuf@04bad49f96a51ec7602024d8c6dd44fde811426d # v1.0.2+
+        uses: jdfalk/gha-release-protobuf@afcb06673c957919bf28b9661b58038931588ea5 # v1.0.2+
 
   # Go Build
   build-go:
@@ -356,7 +356,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Python
-        uses: jdfalk/gha-release-python@d3b2cb559fa2af3f5a12c2cb784cb37b133078d3 # v1.0.2+
+        uses: jdfalk/gha-release-python@120e1dfd3b9379841eb079869681fdacdab71198 # v1.0.2+
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
 
@@ -373,7 +373,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Rust
-        uses: jdfalk/gha-release-rust@85b16e81f014840af704c63c789216f43530117c # v1.0.2+
+        uses: jdfalk/gha-release-rust@1a704db1fba3239c4ce8a543cd35defab6198ca2 # v1.0.2+
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}


### PR DESCRIPTION
## Summary

Updates all `jdfalk/*` action pin SHAs to current main HEAD commits.

### Changes
- `ci-generate-matrices-action`: `42c7fbe` → `96db335`
- `ci-workflow-helpers-action`: `56a8856` → `e64725c`
- `detect-languages-action`: `c10aa6c` → `e8b6061`
- `docs-generator-action`: `38757a4` → `348ba19`
- `get-frontend-config-action`: `3d728dd` → `9a5882d`
- `gha-release-protobuf`: `04bad49` → `afcb066`
- `gha-release-python`: `d3b2cb5` → `120e1df`
- `gha-release-rust`: `85b16e8` → `1a704db`
- `load-config-action`: `f53a2a9` → `482b9f0`
- `pr-auto-label-action`: `6858301` → `5402342`
- `ghcommon self-refs` (reusable-advanced-cache): `06d833f` → `cf20689`

### release.yml fix
Push to main now always creates a prerelease (RC). Dispatch uses provided inputs.
