### PR TITLE
fix(burndown): hardcode runner image in reusable workflow

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -49,9 +49,6 @@ concurrency:
   group: burndown-${{ github.repository }}
   cancel-in-progress: false
 
-env:
-  RUNNER_IMAGE: ghcr.io/jdfalk/burndown-runner-image:bootstrap
-
 defaults:
   run:
     shell: bash
@@ -135,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ${{ env.RUNNER_IMAGE }}
+      image: ghcr.io/jdfalk/burndown-runner-image:bootstrap
     outputs:
       task_indices: ${{ steps.emit.outputs.task_indices }}
       task_count: ${{ steps.emit.outputs.task_count }}
@@ -222,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ${{ env.RUNNER_IMAGE }}
+      image: ghcr.io/jdfalk/burndown-runner-image:bootstrap
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -298,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ${{ env.RUNNER_IMAGE }}
+      image: ghcr.io/jdfalk/burndown-runner-image:bootstrap
     steps:
       - name: Checkout overnight-burndown
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
env context unavailable in container.image for reusable workflow_call jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)