### PR TITLE
fix(burndown): stage triage artifact + graceful aggregate on zero dispatch

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-burndown.yml
-# version: 1.0.0
+# version: 1.1.0
 # Reusable per-repo burndown workflow — lives in ghcommon, called from every repo.
 #
 # Usage:
@@ -193,13 +193,17 @@ jobs:
             --config "$RUNNER_TEMP/config.yaml" \
             --out "$RUNNER_TEMP/tasks.json"
 
+      - name: Stage triage for artifact upload
+        run: |
+          mkdir -p "$RUNNER_TEMP/triage-stage"
+          cp "$RUNNER_TEMP/tasks.json" "$RUNNER_TEMP/triage-stage/tasks.json"
+          cp "$RUNNER_TEMP/config.yaml" "$RUNNER_TEMP/triage-stage/config.yaml"
+
       - name: Upload triage artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: burndown-triage
-          path: |
-            ${{ runner.temp }}/tasks.json
-            ${{ runner.temp }}/config.yaml
+          path: ${{ runner.temp }}/triage-stage/
           retention-days: 7
 
       - name: Emit task indices for matrix
@@ -325,11 +329,19 @@ jobs:
         continue-on-error: true
 
       - name: Aggregate
+        env:
+          BURNDOWN_MODE: ${{ inputs.mode }}
         run: |
           mkdir -p "$RUNNER_TEMP/digest"
+          triage_json="$RUNNER_TEMP/triage/tasks.json"
+          if [ ! -f "$triage_json" ]; then
+            printf '## Burndown — no tasks dispatched\n\nMode: `%s`. All classified tasks were dry-run-only.\n' \
+              "$BURNDOWN_MODE" > "$RUNNER_TEMP/digest/digest.md"
+            exit 0
+          fi
           "$RUNNER_TEMP/burndown" aggregate \
             --config "$RUNNER_TEMP/triage/config.yaml" \
-            --triage-file "$RUNNER_TEMP/triage/tasks.json" \
+            --triage-file "$triage_json" \
             --outcomes-dir "$RUNNER_TEMP/outcomes" \
             --digest-out "$RUNNER_TEMP/digest/digest.md"
 


### PR DESCRIPTION
## Summary
- Stage `tasks.json`/`config.yaml` into a flat `triage-stage/` directory before the upload-artifact step, eliminating host vs container path ambiguity
- Aggregate step now emits a graceful "no tasks dispatched" summary when `tasks.json` is absent (all dry-run-only) instead of crashing with exit 1

## Root cause
`${{ runner.temp }}` (evaluated host-side as `/home/runner/work/_temp`) and `$RUNNER_TEMP` (container env var = `/__w/_temp`) refer to the same volume mount path, but upload-artifact v4 may store the full host-path prefix in artifact metadata. Staging to a clean directory via shell `cp` inside the container ensures upload uses a predictable flat structure.

## Test plan
- [ ] Trigger `nightly-burndown` in dry-run mode — aggregate should complete green with "no tasks dispatched" summary
- [ ] Trigger in `draft-only` mode — aggregate should produce a real digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)