### PR TITLE
fix(burndown): bump runner image to 483ee34 (safe-ai-util-mcp fixed)

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-burndown.yml
-# version: 1.4.0
+# version: 1.5.0
 # Reusable per-repo burndown workflow — lives in ghcommon, called from every repo.
 #
 # Usage:
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:d558a3367025991ebe86e43e46b4d9f73da39b88
+      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     outputs:
       task_indices: ${{ steps.emit.outputs.task_indices }}
       task_count: ${{ steps.emit.outputs.task_count }}
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:d558a3367025991ebe86e43e46b4d9f73da39b88
+      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:d558a3367025991ebe86e43e46b4d9f73da39b88
+      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     steps:
       - name: Download triage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## What

Bumps the pinned runner image in `reusable-burndown.yml` from `d558a33` → `483ee34`.

## Why

Every dispatch job was failing with `safe-ai-util-mcp: executable file not found in $PATH`. Root cause chain:
1. `safe-ai-util-mcp/pyproject.toml` was empty → `mcp` dependency never installed
2. Console-script shebang can't resolve through a symlink chain in Docker → exit 127

## Fixes applied (separate PRs already merged)

- `jdfalk/safe-ai-util-mcp` PR #5: populate `pyproject.toml` with `mcp>=1.1.0`
- `jdfalk/safe-ai-util-mcp` PR #6: fix build backend (`setuptools.build_meta`)
- `jdfalk/burndown-runner-image` PR #12: shell wrapper instead of symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)