### PR TITLE
chore: migrate jdfalk/ refs to falkcorp/ org

### DIFF
--- a/.github/workflows/commit-override-handler.yml
+++ b/.github/workflows/commit-override-handler.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/commit-override-handler.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/commit-override-handler.yml
 
 name: Commit Override Handler
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Generate helper documentation
-        uses: jdfalk/docs-generator-action@8207d873d6300212e4d22b97aa22e9b1114f64a7 # v1.1.3
+        uses: falkcorp/gha-docs-generator@8207d873d6300212e4d22b97aa22e9b1114f64a7 # v1.1.3
         with:
           source-dir: .github/workflows/scripts
           workflows-dir: .github/workflows

--- a/.github/workflows/manager-sync-dispatcher.yml
+++ b/.github/workflows/manager-sync-dispatcher.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/manager-sync-dispatcher.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/manager-sync-dispatcher.yml
 
 name: Manager Sync Dispatcher (DISABLED)
 
@@ -76,7 +76,7 @@ jobs:
         id: repos
         run: |
           # Default repository list - include all target repositories except ghcommon itself
-          DEFAULT_REPOS="jdfalk/subtitle-manager,jdfalk/audiobook-organizer,jdfalk/copilot-agent-util-rust,jdfalk/apt-cacher-go"
+          DEFAULT_REPOS="jdfalk/subtitle-manager,falkcorp/audiobook-organizer,jdfalk/copilot-agent-util-rust,jdfalk/apt-cacher-go"
 
           if [ "$INPUT_TARGET_REPOS" = "auto" ] || [ -z "$INPUT_TARGET_REPOS" ]; then
             echo "repos=$DEFAULT_REPOS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -2,11 +2,11 @@
 # version: 4.5.5
 # guid: a7b8c9d0-e1f2-3456-a789-0123456789bc
 # NOTE: This file should be updated in ghcommon repository first, then copied to other repositories.
-# To update: Edit in https://github.com/jdfalk/ghcommon/.github/workflows/pr-automation.yml then copy to other repos
+# To update: Edit in https://github.com/falkcorp/github-common/.github/workflows/pr-automation.yml then copy to other repos
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/pr-automation.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/pr-automation.yml
 
 name: PR Automation
 
@@ -290,7 +290,7 @@ jobs:
           "
 
       - name: Run intelligent labeling
-        uses: jdfalk/pr-auto-label-action@329b41e704ab05c0ffc2b3581dffa249be11dea4 # v1.1.3
+        uses: falkcorp/gha-pr-auto-label@329b41e704ab05c0ffc2b3581dffa249be11dea4 # v1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.number }}

--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -5,7 +5,7 @@
 # Usage:
 #   jobs:
 #     burndown:
-#       uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@main
+#       uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@main
 #       with:
 #         mode: dry-run
 #       secrets: inherit
@@ -14,7 +14,7 @@
 # Exits early if none found. Otherwise: triage → dispatch (matrix) → aggregate.
 #
 # The burndown binary is pre-baked into
-# ghcr.io/jdfalk/burndown-runner-image:bootstrap at /usr/local/bin/burndown.
+# ghcr.io/falkcorp/burndown-runner-image:bootstrap at /usr/local/bin/burndown.
 # Config is driven entirely by environment variables — no config.yaml needed.
 
 name: Burndown (reusable)
@@ -29,7 +29,7 @@ on:
       hub_repo:
         description: 'GitHub repo holding burndown task issues'
         type: string
-        default: jdfalk/burndown-tasks
+        default: falkcorp/burndown-tasks
       label_prefix:
         description: 'Label prefix routing tasks to repos'
         type: string
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     outputs:
       task_indices: ${{ steps.emit.outputs.task_indices }}
       task_count: ${{ steps.emit.outputs.task_count }}
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     steps:
       - name: Download triage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
     steps:
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -115,14 +115,14 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Load repository configuration
         id: load
-        uses: jdfalk/load-config-action@bb213cbf6b6e789bea8ad0787f2914760d00536b # v1.1.3
+        uses: falkcorp/gha-load-config@bb213cbf6b6e789bea8ad0787f2914760d00536b # v1.1.3
         with:
           config-file: .github/repository-config.yml
           fail-on-missing: false
 
       - name: Generate language matrices
         id: matrices
-        uses: jdfalk/ci-generate-matrices-action@8c36d080ec55e96d3532e9b02417054fc6aaaeac # v1.1.6
+        uses: falkcorp/gha-ci-generate-matrices@8c36d080ec55e96d3532e9b02417054fc6aaaeac # v1.1.6
         with:
           repository-config: ${{ steps.load.outputs.config }}
           fallback-go-version: ${{ inputs.go-version }}
@@ -307,7 +307,7 @@ jobs:
     name: Cache npm (Workflow Scripts)
     needs: detect-changes
     if: needs.detect-changes.outputs.workflows-scripts == 'true' || github.event_name == 'workflow_dispatch'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@1e106b5c7bc2e80beb0c6019e8ac263d41f2ed5f # v1.10.3+
+    uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@1e106b5c7bc2e80beb0c6019e8ac263d41f2ed5f # v1.10.3+
     with:
       language: 'node'
       cache-prefix: 'npm-workflow-scripts'
@@ -391,7 +391,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Generate protobuf
-        uses: jdfalk/gha-release-protobuf@1c07a62621ea5bdaf7fd46643fd4e650c69de8d9 # v1.0.1
+        uses: falkcorp/gha-release-protobuf@1c07a62621ea5bdaf7fd46643fd4e650c69de8d9 # v1.0.1
 
   # Language-specific build and test jobs
   go-ci:
@@ -452,13 +452,13 @@ jobs:
           sudo apt-get install -y $PACKAGES
 
       - name: Build Go project
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: go-setup
 
       - name: Test Go project
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: go-test
           coverage-threshold: ${{ inputs.coverage-threshold || needs.load-config.outputs.coverage-threshold }}
@@ -524,7 +524,7 @@ jobs:
           echo "GHCOMMON_SCRIPTS_DIR=$PWD/ghcommon-workflow-scripts/.github/workflows/scripts" >> "$GITHUB_ENV"
 
       - name: Install Python dependencies
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: python-install
 
@@ -535,7 +535,7 @@ jobs:
 
       - name: Test Python code
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: python-run-tests
 
@@ -598,24 +598,24 @@ jobs:
 
       - name: Format Rust code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: rust-format
 
       - name: Lint Rust code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: rust-clippy
 
       - name: Build Rust project
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: rust-build
 
       - name: Test Rust project
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: rust-test
 
@@ -624,7 +624,7 @@ jobs:
     name: Cache npm (Frontend)
     needs: detect-changes
     if: needs.detect-changes.outputs.frontend-files == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@1e106b5c7bc2e80beb0c6019e8ac263d41f2ed5f # v1.10.3+
+    uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@1e106b5c7bc2e80beb0c6019e8ac263d41f2ed5f # v1.10.3+
     with:
       language: 'node'
       cache-prefix: 'npm-frontend'
@@ -649,7 +649,7 @@ jobs:
 
       - name: Get frontend working directory
         id: frontend-dir
-        uses: jdfalk/get-frontend-config-action@517d41adc382a541ea13dead79a12a57a7172dcf # v1.1.3
+        uses: falkcorp/gha-get-frontend-config@517d41adc382a541ea13dead79a12a57a7172dcf # v1.1.3
         with:
           repository-config: ${{ env.REPOSITORY_CONFIG }}
 
@@ -686,14 +686,14 @@ jobs:
       # No additional cache setup needed here.
 
       - name: Install dependencies
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: frontend-install
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
 
       - name: Lint frontend code
         if: ${{ !inputs.skip-linting }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -702,7 +702,7 @@ jobs:
           frontend-failure-message: '❌ Linting failed or not configured'
 
       - name: Build frontend
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -712,7 +712,7 @@ jobs:
 
       - name: Test frontend
         if: ${{ !inputs.skip-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -735,7 +735,7 @@ jobs:
 
       - name: Run E2E tests
         if: ${{ !inputs.skip-tests && !inputs.skip-e2e-tests }}
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: frontend-run
           frontend-working-dir: ${{ steps.frontend-dir.outputs.dir }}
@@ -825,7 +825,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Generate summary
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: generate-ci-summary
         env:
@@ -840,7 +840,7 @@ jobs:
           JOB_DOCS: skipped
 
       - name: Check overall status
-        uses: jdfalk/ci-workflow-helpers-action@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
+        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
         with:
           command: check-ci-status
         env:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Load repository configuration
         id: load-config
-        uses: jdfalk/load-config-action@bb213cbf6b6e789bea8ad0787f2914760d00536b # v1.1.3
+        uses: falkcorp/gha-load-config@bb213cbf6b6e789bea8ad0787f2914760d00536b # v1.1.3
         with:
           config-file: .github/repository-config.yml
           fail-on-missing: false
@@ -174,7 +174,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Detect project languages and generate matrices
         id: detect
-        uses: jdfalk/detect-languages-action@d5712363aae458b4bbb47bbb1780f02de2a03784 # v1.1.5
+        uses: falkcorp/gha-detect-languages@d5712363aae458b4bbb47bbb1780f02de2a03784 # v1.1.5
         with:
           skip-detection: ${{ inputs.skip-language-detection }}
           build-target: ${{ inputs.build-target || 'all' }}
@@ -299,7 +299,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Generate protobuf
-        uses: jdfalk/gha-release-protobuf@1c07a62621ea5bdaf7fd46643fd4e650c69de8d9 # v1.0.2+
+        uses: falkcorp/gha-release-protobuf@1c07a62621ea5bdaf7fd46643fd4e650c69de8d9 # v1.0.2+
 
   # Go Build
   build-go:
@@ -344,7 +344,7 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
       - name: Build Go
-        uses: jdfalk/gha-release-go@68295f41570b9f4fd264bb0a167a43b79ca30310 # v1.1.0
+        uses: falkcorp/gha-release-go@68295f41570b9f4fd264bb0a167a43b79ca30310 # v1.1.0
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
@@ -366,7 +366,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Python
-        uses: jdfalk/gha-release-python@900b75fc7585c37cf448dbb7e30330f5ff891607 # v1.0.2+
+        uses: falkcorp/gha-release-python@900b75fc7585c37cf448dbb7e30330f5ff891607 # v1.0.2+
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
 
@@ -383,7 +383,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Rust
-        uses: jdfalk/gha-release-rust@5e0cfb831f58d00fc22e4dfe6d7e51a97eb6dbcd # v1.0.2+
+        uses: falkcorp/gha-release-rust@5e0cfb831f58d00fc22e4dfe6d7e51a97eb6dbcd # v1.0.2+
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
@@ -401,7 +401,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Frontend
-        uses: jdfalk/gha-release-frontend@3fe7d567a6a6f25cadb618a3cb0abe311c765abb # v1.0.2+
+        uses: falkcorp/gha-release-frontend@3fe7d567a6a6f25cadb618a3cb0abe311c765abb # v1.0.2+
 
   # Docker Build
   build-docker:
@@ -416,7 +416,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Build Docker
-        uses: jdfalk/gha-release-docker@2f0979263a455d556526d9f53589c3eb4d837136 # v1.0.2+
+        uses: falkcorp/gha-release-docker@2f0979263a455d556526d9f53589c3eb4d837136 # v1.0.2+
         with:
           registry: ${{ needs.detect-languages.outputs.registry }}
           image-name: ${{ needs.detect-languages.outputs.image-name }}
@@ -499,7 +499,7 @@ jobs:
           path: ./artifacts
       - name: Package and organize release artifacts
         id: package-artifacts
-        uses: jdfalk/package-assets-action@c1dc41c8fb6800606eee2714da4d7b807d55ecc4 # v1.2.0
+        uses: falkcorp/gha-package-assets@c1dc41c8fb6800606eee2714da4d7b807d55ecc4 # v1.2.0
         with:
           artifacts-dir: ./artifacts
 

--- a/.github/workflows/reusable-triage-poll.yml
+++ b/.github/workflows/reusable-triage-poll.yml
@@ -5,7 +5,7 @@
 # Usage:
 #   jobs:
 #     triage-poll:
-#       uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@main
+#       uses: falkcorp/github-common/.github/workflows/reusable-triage-poll.yml@main
 #       secrets: inherit
 #
 # State machine (one iteration per invocation, zero AI cost for idle runs):
@@ -29,7 +29,7 @@ on:
       hub_repo:
         description: 'GitHub repo holding burndown task issues'
         type: string
-        default: jdfalk/burndown-tasks
+        default: falkcorp/burndown-tasks
       label_prefix:
         description: 'Label prefix routing tasks to repos'
         type: string
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/jdfalk/burndown-runner-image:d558a3367025991ebe86e43e46b4d9f73da39b88
+      image: ghcr.io/falkcorp/burndown-runner-image:d558a3367025991ebe86e43e46b4d9f73da39b88
     steps:
       - name: Materialize App key
         env:

--- a/.github/workflows/sync-receiver.yml
+++ b/.github/workflows/sync-receiver.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/sync-receiver.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/sync-receiver.yml
 
 name: Sync Receiver (DISABLED)
 

--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -6,7 +6,7 @@ on:
       repos:
         description: 'Comma-separated list of repos to sync (owner/repo format)'
         required: true
-        default: 'jdfalk/audiobook-organizer,jdfalk/apt-cacher-go,jdfalk/subtitle-manager,jdfalk/safe-ai-util,jdfalk/gcommon-proto,jdfalk/transcoderr,jdfalk/ubuntu-autoinstall-webhook,jdfalk/public-scratch,jdfalk/project-template,jdfalk/magnet-handler'
+        default: 'falkcorp/audiobook-organizer,jdfalk/apt-cacher-go,jdfalk/subtitle-manager,falkcorp/safe-ai-util,falkcorp/gcommon-proto,jdfalk/transcoderr,jdfalk/ubuntu-autoinstall-webhook,jdfalk/public-scratch,jdfalk/project-template,jdfalk/magnet-handler'
       branch:
         description: 'Branch name for sync changes'
         required: false

--- a/.github/workflows/unified-automation.yml
+++ b/.github/workflows/unified-automation.yml
@@ -4,7 +4,7 @@
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
 # All changes should be made in jdfalk/ghcommon and will be synced to other repositories
-# Edit this file at: https://github.com/jdfalk/ghcommon/edit/main/.github/workflows/unified-automation.yml
+# Edit this file at: https://github.com/falkcorp/github-common/edit/main/.github/workflows/unified-automation.yml
 
 name: Unified Automation
 

--- a/ACTIONS_IMPLEMENTATION_COMPLETE.md
+++ b/ACTIONS_IMPLEMENTATION_COMPLETE.md
@@ -32,7 +32,7 @@ each action
 Loads `.github/repository-config.yml` and outputs JSON for downstream actions.
 
 ```yaml
-uses: jdfalk/load-config-action@v1.0.0
+uses: falkcorp/gha-load-config@v1.0.0
 ```
 
 ### 2️⃣ ci-generate-matrices-action
@@ -40,7 +40,7 @@ uses: jdfalk/load-config-action@v1.0.0
 Generates CI test matrices for Go, Python, Rust, Node.js based on config.
 
 ```yaml
-uses: jdfalk/ci-generate-matrices-action@v1.0.0
+uses: falkcorp/gha-ci-generate-matrices@v1.0.0
 with:
   repository-config: ${{ steps.config.outputs.config }}
 ```
@@ -50,7 +50,7 @@ with:
 Auto-detects project languages and generates basic CI matrices.
 
 ```yaml
-uses: jdfalk/detect-languages-action@v1.0.0
+uses: falkcorp/gha-detect-languages@v1.0.0
 ```
 
 ### 4️⃣ release-strategy-action
@@ -58,7 +58,7 @@ uses: jdfalk/detect-languages-action@v1.0.0
 Determines release strategy (stable/prerelease/draft) based on branch.
 
 ```yaml
-uses: jdfalk/release-strategy-action@v1.0.0
+uses: falkcorp/gha-release-strategy@v1.0.0
 with:
   branch-name: ${{ github.ref_name }}
 ```
@@ -68,7 +68,7 @@ with:
 Generates semantic versions (major/minor/patch) with git tag detection.
 
 ```yaml
-uses: jdfalk/generate-version-action@v1.0.0
+uses: falkcorp/gha-generate-version@v1.0.0
 with:
   release-type: auto
 ```
@@ -78,7 +78,7 @@ with:
 Packages artifacts and generates SHA256 checksums for releases.
 
 ```yaml
-uses: jdfalk/package-assets-action@v1.0.0
+uses: falkcorp/gha-package-assets@v1.0.0
 with:
   artifacts-dir: dist
 ```
@@ -131,7 +131,7 @@ runs:
 ### For External Repositories
 
 1. Replace old workflow script calls with action references
-2. Use actions like: `uses: jdfalk/detect-languages-action@v1.0.0`
+2. Use actions like: `uses: falkcorp/gha-detect-languages@v1.0.0`
 3. Benefit from centralized, maintained scripts
 
 ### For audiobook-organizer
@@ -192,16 +192,16 @@ All 6 action repositories are in your VS Code workspace:
 
 ```bash
 # Add to your workflow
-- uses: jdfalk/load-config-action@v1.0.0
+- uses: falkcorp/gha-load-config@v1.0.0
   id: config
 ```
 
 ### Chain Actions
 
 ```yaml
-- uses: jdfalk/detect-languages-action@v1.0.0
+- uses: falkcorp/gha-detect-languages@v1.0.0
   id: detect
-- uses: jdfalk/ci-generate-matrices-action@v1.0.0
+- uses: falkcorp/gha-ci-generate-matrices@v1.0.0
   with:
     repository-config: ${{ steps.config.outputs.config }}
 ```
@@ -209,9 +209,9 @@ All 6 action repositories are in your VS Code workspace:
 ### Full Release Workflow
 
 ```yaml
-- uses: jdfalk/generate-version-action@v1.0.0
+- uses: falkcorp/gha-generate-version@v1.0.0
   id: version
-- uses: jdfalk/release-strategy-action@v1.0.0
+- uses: falkcorp/gha-release-strategy@v1.0.0
   id: strategy
   with:
     branch-name: ${{ github.ref_name }}

--- a/ACTIONS_IMPLEMENTATION_SUMMARY.md
+++ b/ACTIONS_IMPLEMENTATION_SUMMARY.md
@@ -184,19 +184,19 @@ jobs:
       # Load repository configuration
       - name: Load config
         id: config
-        uses: jdfalk/load-config-action@v1.0.0
+        uses: falkcorp/gha-load-config@v1.0.0
         with:
           config-file: .github/repository-config.yml
 
       # Detect languages
       - name: Detect languages
         id: detect
-        uses: jdfalk/detect-languages-action@v1.0.0
+        uses: falkcorp/gha-detect-languages@v1.0.0
 
       # Generate version
       - name: Generate version
         id: version
-        uses: jdfalk/generate-version-action@v1.0.0
+        uses: falkcorp/gha-generate-version@v1.0.0
         with:
           release-type: auto
           branch-name: ${{ github.ref_name }}
@@ -204,7 +204,7 @@ jobs:
       # Determine strategy
       - name: Determine strategy
         id: strategy
-        uses: jdfalk/release-strategy-action@v1.0.0
+        uses: falkcorp/gha-release-strategy@v1.0.0
         with:
           branch-name: ${{ github.ref_name }}
 

--- a/ACTIONS_INTEGRATION_GUIDE.md
+++ b/ACTIONS_INTEGRATION_GUIDE.md
@@ -25,7 +25,7 @@ use the new GitHub Actions instead of inline scripts.
 
 ```yaml
 # This works everywhere
-- uses: jdfalk/load-config-action@v1.0.0
+- uses: falkcorp/gha-load-config@v1.0.0
 ```
 
 ## Integration Examples
@@ -46,7 +46,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Load repository config
   id: config
-  uses: jdfalk/load-config-action@v1.0.0
+  uses: falkcorp/gha-load-config@v1.0.0
   with:
     config-file: .github/repository-config.yml
     fail-on-missing: false
@@ -70,7 +70,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Generate CI matrices
   id: matrices
-  uses: jdfalk/ci-generate-matrices-action@v1.0.0
+  uses: falkcorp/gha-ci-generate-matrices@v1.0.0
   with:
     repository-config: ${{ steps.config.outputs.config }}
     fallback-go-version: '1.23'
@@ -92,7 +92,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Detect languages
   id: detect
-  uses: jdfalk/detect-languages-action@v1.0.0
+  uses: falkcorp/gha-detect-languages@v1.0.0
   with:
     skip-detection: false
 ```
@@ -113,7 +113,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Determine release strategy
   id: strategy
-  uses: jdfalk/release-strategy-action@v1.0.0
+  uses: falkcorp/gha-release-strategy@v1.0.0
   with:
     branch-name: ${{ github.ref_name }}
 ```
@@ -136,7 +136,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Generate semantic version
   id: version
-  uses: jdfalk/generate-version-action@v1.0.0
+  uses: falkcorp/gha-generate-version@v1.0.0
   with:
     release-type: auto
     branch-name: ${{ github.ref_name }}
@@ -159,7 +159,7 @@ use the new GitHub Actions instead of inline scripts.
 ```yaml
 - name: Package assets
   id: package
-  uses: jdfalk/package-assets-action@v1.0.0
+  uses: falkcorp/gha-package-assets@v1.0.0
   with:
     artifacts-dir: dist
 ```
@@ -195,17 +195,17 @@ jobs:
 
       - name: Load config
         id: config
-        uses: jdfalk/load-config-action@v1.0.0
+        uses: falkcorp/gha-load-config@v1.0.0
         with:
           config-file: ${{ inputs.config-file }}
 
       - name: Detect languages
         id: detect
-        uses: jdfalk/detect-languages-action@v1.0.0
+        uses: falkcorp/gha-detect-languages@v1.0.0
 
       - name: Generate matrices
         id: matrices
-        uses: jdfalk/ci-generate-matrices-action@v1.0.0
+        uses: falkcorp/gha-ci-generate-matrices@v1.0.0
         with:
           repository-config: ${{ steps.config.outputs.config }}
 
@@ -266,7 +266,7 @@ jobs:
       # NEW: Use action for version generation
       - name: Generate version
         id: version
-        uses: jdfalk/generate-version-action@v1.0.0
+        uses: falkcorp/gha-generate-version@v1.0.0
         with:
           release-type: ${{ inputs.release-type }}
           branch-name: ${{ github.ref_name }}
@@ -274,14 +274,14 @@ jobs:
       # NEW: Use action for strategy detection
       - name: Determine strategy
         id: strategy
-        uses: jdfalk/release-strategy-action@v1.0.0
+        uses: falkcorp/gha-release-strategy@v1.0.0
         with:
           branch-name: ${{ github.ref_name }}
 
       # NEW: Use action for asset packaging
       - name: Package assets
         id: package
-        uses: jdfalk/package-assets-action@v1.0.0
+        uses: falkcorp/gha-package-assets@v1.0.0
         with:
           artifacts-dir: dist
 
@@ -345,7 +345,7 @@ Ensure you're using the correct GitHub org and action name:
 
 ```yaml
 # Correct
-uses: jdfalk/detect-languages-action@v1.0.0
+uses: falkcorp/gha-detect-languages@v1.0.0
 
 # Incorrect
 uses: detect-languages-action@v1.0.0  # Missing org

--- a/ACTIONS_VERIFICATION_REPORT.md
+++ b/ACTIONS_VERIFICATION_REPORT.md
@@ -235,42 +235,42 @@ runs:
 ### load-config-action
 
 ```yaml
-uses: jdfalk/load-config-action@v1.0.0
+uses: falkcorp/gha-load-config@v1.0.0
 # Outputs: config, has-config, raw-yaml
 ```
 
 ### ci-generate-matrices-action
 
 ```yaml
-uses: jdfalk/ci-generate-matrices-action@v1.0.0
+uses: falkcorp/gha-ci-generate-matrices@v1.0.0
 # Outputs: go-matrix, python-matrix, rust-matrix, frontend-matrix, coverage-threshold
 ```
 
 ### detect-languages-action
 
 ```yaml
-uses: jdfalk/detect-languages-action@v1.0.0
+uses: falkcorp/gha-detect-languages@v1.0.0
 # Outputs: has-go, has-python, has-rust, has-frontend, has-docker, protobuf-needed, etc.
 ```
 
 ### release-strategy-action
 
 ```yaml
-uses: jdfalk/release-strategy-action@v1.0.0
+uses: falkcorp/gha-release-strategy@v1.0.0
 # Outputs: strategy, auto-prerelease, auto-draft, is-stable, is-prerelease, is-draft
 ```
 
 ### generate-version-action
 
 ```yaml
-uses: jdfalk/generate-version-action@v1.0.0
+uses: falkcorp/gha-generate-version@v1.0.0
 # Outputs: tag, version, major, minor, patch, prerelease
 ```
 
 ### package-assets-action
 
 ```yaml
-uses: jdfalk/package-assets-action@v1.0.0
+uses: falkcorp/gha-package-assets@v1.0.0
 # Outputs: assets, checksums
 ```
 

--- a/ACTION_ARCHITECTURE_DESIGN.md
+++ b/ACTION_ARCHITECTURE_DESIGN.md
@@ -243,7 +243,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: jdfalk/load-config-action@v1
+      - uses: falkcorp/gha-load-config@v1
         id: config
         with:
           config-file: .github/repository-config.yml
@@ -529,9 +529,9 @@ jobs:
       python-matrix: ${{ steps.matrices.outputs.python-matrix }}
     steps:
       - uses: actions/checkout@v6
-      - uses: jdfalk/load-config-action@v1
+      - uses: falkcorp/gha-load-config@v1
         id: config
-      - uses: jdfalk/ci-generate-matrices-action@v1
+      - uses: falkcorp/gha-ci-generate-matrices@v1
         id: matrices
         with:
           repository-config: ${{ steps.config.outputs.config }}

--- a/ACTION_DEPLOYMENT_CHECKLIST.md
+++ b/ACTION_DEPLOYMENT_CHECKLIST.md
@@ -278,7 +278,7 @@ jobs:
   test-docker-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: jdfalk/release-docker-action@v1
+      - uses: falkcorp/gha-release-docker@v1
         with:
           version: '1.0.0'
           # ... other inputs
@@ -286,7 +286,7 @@ jobs:
   test-go-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: jdfalk/release-go-action@v1
+      - uses: falkcorp/gha-release-go@v1
         with:
           version: '1.0.0'
           # ... other inputs

--- a/ACTION_FIX_AND_TAG_SUMMARY.md
+++ b/ACTION_FIX_AND_TAG_SUMMARY.md
@@ -85,10 +85,10 @@ The tagging script creates three tags:
 
 This follows GitHub Actions best practices where users can:
 
-- Pin to exact version: `uses: jdfalk/release-docker-action@v1.0.0`
-- Pin to minor: `uses: jdfalk/release-docker-action@v1.0` (gets patches
+- Pin to exact version: `uses: falkcorp/gha-release-docker@v1.0.0`
+- Pin to minor: `uses: falkcorp/gha-release-docker@v1.0` (gets patches
   automatically)
-- Pin to major: `uses: jdfalk/release-docker-action@v1` (gets all non-breaking
+- Pin to major: `uses: falkcorp/gha-release-docker@v1` (gets all non-breaking
   updates)
 
 ## Force Tag Updates
@@ -118,7 +118,7 @@ All 7 action repositories are:
 directly from GitHub repositories using:
 
 ```yaml
-uses: jdfalk/release-docker-action@v1
+uses: falkcorp/gha-release-docker@v1
 ```
 
 GitHub automatically provides:

--- a/ACTION_PINNING_PLAN.md
+++ b/ACTION_PINNING_PLAN.md
@@ -197,7 +197,7 @@ For each reusable workflow, replace the inline steps with action calls:
 
 ```yaml
 - name: Release Go project
-   uses: jdfalk/release-go-action@abc1234 # v2.0.1
+   uses: falkcorp/gha-release-go@abc1234 # v2.0.1
   with:
     go-version: '1.21'
     project-path: '.'
@@ -242,7 +242,7 @@ uses: jdfalk/ACTION-NAME@COMMIT_HASH # vX.Y.Z
 **Example:**
 
 ```yaml
-uses: jdfalk/release-go-action@abc1234 # v2.0.1
+uses: falkcorp/gha-release-go@abc1234 # v2.0.1
 ```
 
 **Why:**
@@ -269,7 +269,7 @@ If issues arise:
 
    ```bash
    # In consuming workflow
-   uses: jdfalk/release-go-action@OLD_HASH # v1.x.x
+   uses: falkcorp/gha-release-go@OLD_HASH # v1.x.x
    ```
 
 2. **Workflow Issues:** Revert commit

--- a/ACTION_VERSIONS.md
+++ b/ACTION_VERSIONS.md
@@ -12,15 +12,15 @@ actions.
 
 ## Action Versions
 
-| Action Repository          | Version | Commit Hash | Usage                                                |
-| -------------------------- | ------- | ----------- | ---------------------------------------------------- |
-| auto-module-tagging-action | v1.0.0  | `992b70e`   | `jdfalk/auto-module-tagging-action@992b70e # v1.0.0` |
-| release-docker-action      | v1.0.0  | `7a5440f`   | `jdfalk/release-docker-action@7a5440f # v1.0.0`      |
-| release-frontend-action    | v1.0.0  | `4292378`   | `jdfalk/release-frontend-action@4292378 # v1.0.0`    |
-| release-go-action          | v2.0.1  | `8e3ea4b`   | `jdfalk/release-go-action@8e3ea4b # v2.0.1`          |
-| release-protobuf-action    | v1.0.0  | `0ea205f`   | `jdfalk/release-protobuf-action@0ea205f # v1.0.0`    |
-| release-python-action      | v1.0.0  | `a5acdd5`   | `jdfalk/release-python-action@a5acdd5 # v1.0.0`      |
-| release-rust-action        | v1.0.0  | `0c21e31`   | `jdfalk/release-rust-action@0c21e31 # v1.0.0`        |
+| Action Repository          | Version | Commit Hash | Usage                                                 |
+| -------------------------- | ------- | ----------- | ----------------------------------------------------- |
+| auto-module-tagging-action | v1.0.0  | `992b70e`   | `falkcorp/gha-auto-module-tagging@992b70e # v1.0.0`   |
+| release-docker-action      | v1.0.0  | `7a5440f`   | `falkcorp/gha-release-docker@7a5440f # v1.0.0`        |
+| release-frontend-action    | v1.0.0  | `4292378`   | `falkcorp/gha-release-frontend@4292378 # v1.0.0`      |
+| release-go-action          | v2.0.1  | `8e3ea4b`   | `falkcorp/gha-release-go@8e3ea4b # v2.0.1`            |
+| release-protobuf-action    | v1.0.0  | `0ea205f`   | `falkcorp/gha-release-protobuf-base@0ea205f # v1.0.0` |
+| release-python-action      | v1.0.0  | `a5acdd5`   | `falkcorp/gha-release-python@a5acdd5 # v1.0.0`        |
+| release-rust-action        | v1.0.0  | `0c21e31`   | `falkcorp/gha-release-rust@0c21e31 # v1.0.0`          |
 
 ## Update Instructions
 

--- a/CACHE_STRATEGY_IMPLEMENTATION.md
+++ b/CACHE_STRATEGY_IMPLEMENTATION.md
@@ -55,7 +55,7 @@ outputs:
 - **Trigger**: Runs when workflow scripts are detected or on workflow_dispatch
 - **Configuration**:
   ```yaml
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-workflow-scripts'
@@ -73,7 +73,7 @@ outputs:
 - **Trigger**: Runs when frontend files are detected
 - **Configuration**:
   ```yaml
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-frontend'
@@ -177,7 +177,7 @@ outputs:
 2. **Trigger audiobook-organizer CI**:
 
    ```bash
-   cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+   cd /Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer
    gh workflow run ci.yml --ref main
    ```
 

--- a/CACHE_STRATEGY_SUMMARY.md
+++ b/CACHE_STRATEGY_SUMMARY.md
@@ -45,7 +45,7 @@ workflow-scripts-npm-cache:
   if:
     needs.detect-changes.outputs.workflows-scripts == 'true' ||
     github.event_name == 'workflow_dispatch'
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-workflow-scripts'
@@ -75,7 +75,7 @@ frontend-npm-cache:
   name: Cache npm (Frontend)
   needs: detect-changes
   if: needs.detect-changes.outputs.frontend-files == 'true'
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-frontend'
@@ -220,7 +220,7 @@ Ensures cache jobs complete before generating final summary.
 **Trigger CI Run**:
 
 ```bash
-cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+cd /Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer
 gh workflow run ci.yml --ref main
 ```
 

--- a/CACHE_TESTING_GUIDE.md
+++ b/CACHE_TESTING_GUIDE.md
@@ -31,7 +31,7 @@ de881bd (HEAD -> main) feat(cache): implement robust advanced caching strategy f
 ### 2. Trigger CI in audiobook-organizer
 
 ```bash
-cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+cd /Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer
 gh workflow run ci.yml --ref main
 ```
 
@@ -46,7 +46,7 @@ gh workflow run ci.yml --ref main
 
 ```bash
 # In browser
-https://github.com/jdfalk/audiobook-organizer/actions
+https://github.com/falkcorp/audiobook-organizer/actions
 ```
 
 ---
@@ -119,13 +119,13 @@ Date: ...
 **Method A: Using GitHub CLI**
 
 ```bash
-cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+cd /Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer
 gh workflow run ci.yml --ref main
 ```
 
 **Method B: Using GitHub Web UI**
 
-1. Navigate to: <https://github.com/jdfalk/audiobook-organizer/actions>
+1. Navigate to: <https://github.com/falkcorp/audiobook-organizer/actions>
 2. Click "CI" workflow on left
 3. Click "Run workflow" button
 4. Select "main" branch
@@ -137,7 +137,7 @@ gh workflow run ci.yml --ref main
 
 **Navigation**:
 
-1. Go to: <https://github.com/jdfalk/audiobook-organizer/actions>
+1. Go to: <https://github.com/falkcorp/audiobook-organizer/actions>
 2. Click the latest "CI" run
 3. Wait for jobs to appear (should see within 30 seconds)
 

--- a/CACHE_YAML_DIFFS.md
+++ b/CACHE_YAML_DIFFS.md
@@ -95,7 +95,7 @@ workflow-scripts-npm-cache:
   if:
     needs.detect-changes.outputs.workflows-scripts == 'true' ||
     github.event_name == 'workflow_dispatch'
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-workflow-scripts'
@@ -182,7 +182,7 @@ frontend-npm-cache:
   name: Cache npm (Frontend)
   needs: detect-changes
   if: needs.detect-changes.outputs.frontend-files == 'true'
-  uses: jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-advanced-cache.yml@main
   with:
     language: 'node'
     cache-prefix: 'npm-frontend'
@@ -215,7 +215,7 @@ frontend-npm-cache:
 
       - name: Get frontend working directory
         id: frontend-dir
-        uses: jdfalk/get-frontend-config-action@v1
+        uses: falkcorp/gha-get-frontend-config@v1
         with:
           repository-config: ${{ env.REPOSITORY_CONFIG }}
 

--- a/COSIGN_VERIFICATION.md
+++ b/COSIGN_VERIFICATION.md
@@ -98,9 +98,9 @@ SIGNATURE="go-build-all.tar.gz.sig"
 PUBLIC_KEY="cosign.pub"
 
 # Download files (adjust URLs as needed)
-curl -L -o "$ARTIFACT" "https://github.com/jdfalk/ghcommon/releases/download/v1.0.0/$ARTIFACT"
-curl -L -o "$SIGNATURE" "https://github.com/jdfalk/ghcommon/releases/download/v1.0.0/$SIGNATURE"
-curl -L -o "$PUBLIC_KEY" "https://github.com/jdfalk/ghcommon/releases/download/v1.0.0/$PUBLIC_KEY"
+curl -L -o "$ARTIFACT" "https://github.com/falkcorp/github-common/releases/download/v1.0.0/$ARTIFACT"
+curl -L -o "$SIGNATURE" "https://github.com/falkcorp/github-common/releases/download/v1.0.0/$SIGNATURE"
+curl -L -o "$PUBLIC_KEY" "https://github.com/falkcorp/github-common/releases/download/v1.0.0/$PUBLIC_KEY"
 
 # Verify signature
 if cosign verify-blob --key "$PUBLIC_KEY" --signature "$SIGNATURE" "$ARTIFACT"; then

--- a/OVERNIGHT_PROGRESS_SUMMARY.md
+++ b/OVERNIGHT_PROGRESS_SUMMARY.md
@@ -184,12 +184,12 @@ Created comprehensive guides:
 
 ## 📁 Important Files to Review
 
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/TODO.md` - Task list
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/ACTION_PINNING_PLAN.md` -
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/TODO.md` - Task list
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/ACTION_PINNING_PLAN.md` -
   Pinning strategy
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/pin-actions-to-hashes.py` -
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/pin-actions-to-hashes.py` -
   Pinning script
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/tag-release-go-v2.sh` -
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/tag-release-go-v2.sh` -
   Tagging script
 - `/Users/jdfalk/repos/github.com/jdfalk/release-go-action/TODO.md` - Go action
   issues

--- a/PHASE_2_PROGRESS.md
+++ b/PHASE_2_PROGRESS.md
@@ -39,7 +39,7 @@ that:
 ### 🏗️ Architecture Benefits
 
 - **Reusable**: Can be called from any repository with
-  `uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@main`
+  `uses: falkcorp/github-common/.github/workflows/reusable-release.yml@main`
 - **Maintainable**: Centralized release logic with language-specific delegation
 - **Configurable**: All settings controlled via repository-config.yml
 - **Comprehensive**: Handles protobuf generation, multi-language builds, release
@@ -86,7 +86,7 @@ on:
 
 jobs:
   release:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@main
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@main
     with:
       version-type: ${{ inputs.version-type || 'patch' }}
       build-target: 'all'

--- a/PR-AUTOMATION-SETUP.md
+++ b/PR-AUTOMATION-SETUP.md
@@ -10,7 +10,7 @@ PRs across all repositories.
 ### 1. **PR Created for ghcommon Changes**
 
 - **PR #199**:
-  [fix(sync): resolve git authentication and branch creation bugs in sync script](https://github.com/jdfalk/ghcommon/pull/199)
+  [fix(sync): resolve git authentication and branch creation bugs in sync script](https://github.com/falkcorp/github-common/pull/199)
 - **Status**: Ready for review and merge
 - **Changes**:
   - Fixed sync script v1.2.0 (authentication, branch creation, error handling)
@@ -71,13 +71,13 @@ The sync process now follows this complete workflow:
 ```bash
 # Run sync script
 GH_TOKEN="$(gh auth token)" python3 scripts/intelligent_sync_to_repos.py \
-  --repos jdfalk/audiobook-organizer \
+  --repos falkcorp/audiobook-organizer \
   --branch chore/sync-copilot-agents
 
 # Output:
-# [OK] jdfalk/audiobook-organizer: Synced to branch chore/sync-copilot-agents
-# [PR] jdfalk/audiobook-organizer: Created PR at https://github.com/jdfalk/audiobook-organizer/pull/XX
-# [PR] jdfalk/audiobook-organizer: Closed superseded PR #YY
+# [OK] falkcorp/audiobook-organizer: Synced to branch chore/sync-copilot-agents
+# [PR] falkcorp/audiobook-organizer: Created PR at https://github.com/falkcorp/audiobook-organizer/pull/XX
+# [PR] falkcorp/audiobook-organizer: Closed superseded PR #YY
 ```
 
 ## Next Steps
@@ -93,7 +93,7 @@ GH_TOKEN="$(gh auth token)" python3 scripts/intelligent_sync_to_repos.py \
 ```bash
 # Example: Sync to multiple repos
 GH_TOKEN="$(gh auth token)" python3 scripts/intelligent_sync_to_repos.py \
-  --repos jdfalk/audiobook-organizer,jdfalk/apt-cacher-go,jdfalk/subtitle-manager \
+  --repos falkcorp/audiobook-organizer,jdfalk/apt-cacher-go,jdfalk/subtitle-manager \
   --branch chore/sync-copilot-infrastructure
 ```
 
@@ -106,7 +106,7 @@ GH_TOKEN="$(gh auth token)" python3 scripts/intelligent_sync_to_repos.py \
 
 ## Files Modified
 
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/intelligent_sync_to_repos.py`
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/intelligent_sync_to_repos.py`
   - Version: 1.2.0 → 1.3.0
   - Added: `create_or_update_pr()` function (73 lines)
   - Added: Superseded PR closing logic
@@ -114,7 +114,7 @@ GH_TOKEN="$(gh auth token)" python3 scripts/intelligent_sync_to_repos.py \
 
 ## PR Status
 
-- **PR #199**: <https://github.com/jdfalk/ghcommon/pull/199>
+- **PR #199**: <https://github.com/falkcorp/github-common/pull/199>
 - **Branch**: `chore/sync-script-fix`
 - **Files Changed**: 2
 - **Lines Added**: 118

--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -68,7 +68,7 @@ All repositories are on `main` branch and have been pushed to GitHub:
 
 ### 📝 audiobook-organizer
 
-- **PR**: <https://github.com/jdfalk/audiobook-organizer/pull/66>
+- **PR**: <https://github.com/falkcorp/audiobook-organizer/pull/66>
 - **Branch**: worktree-2025-12-19T00-55-46
 - **Changes**:
   - Added GoReleaser configuration

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 # GitHub Common Workflows
 
-[![Continuous Integration](https://github.com/jdfalk/ghcommon/actions/workflows/ci.yml/badge.svg)](https://github.com/jdfalk/ghcommon/actions/workflows/ci.yml)
-[![CI Self Tests](https://github.com/jdfalk/ghcommon/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/jdfalk/ghcommon/actions/workflows/ci-tests.yml)
-[![CodeQL](https://github.com/jdfalk/ghcommon/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/jdfalk/ghcommon/actions/workflows/github-code-scanning/codeql)
-[![Security Scans](https://github.com/jdfalk/ghcommon/actions/workflows/security.yml/badge.svg)](https://github.com/jdfalk/ghcommon/actions/workflows/security.yml)
+[![Continuous Integration](https://github.com/falkcorp/github-common/actions/workflows/ci.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/ci.yml)
+[![CI Self Tests](https://github.com/falkcorp/github-common/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/ci-tests.yml)
+[![CodeQL](https://github.com/falkcorp/github-common/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/github-code-scanning/codeql)
+[![Security Scans](https://github.com/falkcorp/github-common/actions/workflows/security.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/security.yml)
 
 ## Table of Contents
 
@@ -68,19 +68,19 @@ Choose the setup that matches your project type:
 ### For Complete CI/CD Pipeline
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/setup-repository.sh | bash -s complete
+curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s complete
 ```
 
 ### For Container-Only Projects
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/setup-repository.sh | bash -s container
+curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s container
 ```
 
 ### For Library/Package Projects
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/setup-repository.sh | bash -s library
+curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s library
 ```
 
 ## 📋 What's Included
@@ -195,7 +195,7 @@ curl -sSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/setup-r
 
 ```yaml
 versioning:
-  uses: jdfalk/ghcommon/.github/workflows/reusable-semantic-versioning.yml@main
+  uses: falkcorp/github-common/.github/workflows/reusable-semantic-versioning.yml@main
   with:
     version-files: '["package.json", "version.txt"]'
     update-pr-title: true
@@ -206,7 +206,7 @@ versioning:
 
 ```yaml
 container:
-  uses: jdfalk/ghcommon/.github/workflows/buildah-multiarch.yml@main
+  uses: falkcorp/github-common/.github/workflows/buildah-multiarch.yml@main
   with:
     image-name: my-app
     platforms: linux/amd64,linux/arm64
@@ -219,7 +219,7 @@ container:
 
 ```yaml
 release:
-  uses: jdfalk/ghcommon/.github/workflows/automatic-release.yml@main
+  uses: falkcorp/github-common/.github/workflows/automatic-release.yml@main
   with:
     release-type: auto
     include-artifacts: true
@@ -245,7 +245,7 @@ on:
 
 jobs:
   issue-management:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-unified-issue-management.yml@main
+    uses: falkcorp/github-common/.github/workflows/reusable-unified-issue-management.yml@main
     with:
       operations: 'auto' # Auto-detect based on event
       issue_updates_file: 'issue_updates.json'
@@ -266,7 +266,7 @@ on:
 
 jobs:
   sync-labels:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-label-sync.yml@main
+    uses: falkcorp/github-common/.github/workflows/reusable-label-sync.yml@main
     with:
       repositories: ${{ github.repository }}
       source-repo: 'jdfalk/ghcommon'
@@ -290,7 +290,7 @@ jobs:
 **Helper Script**: Copy the issue creation helper to your repository:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/create-issue-update.sh -o scripts/create-issue-update.sh
+curl -fsSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/create-issue-update.sh -o scripts/create-issue-update.sh
 chmod +x scripts/create-issue-update.sh
 
 # Usage examples:
@@ -351,7 +351,7 @@ chmod +x scripts/create-issue-update.sh
 Validate your repository setup:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/jdfalk/ghcommon/main/scripts/validate-setup.sh | bash
+curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/validate-setup.sh | bash
 ```
 
 This will check:
@@ -382,9 +382,9 @@ for details.
 
 ## 🆘 Support
 
-- **Issues**: [GitHub Issues](https://github.com/jdfalk/ghcommon/issues)
+- **Issues**: [GitHub Issues](https://github.com/falkcorp/github-common/issues)
 - **Discussions**:
-  [GitHub Discussions](https://github.com/jdfalk/ghcommon/discussions)
+  [GitHub Discussions](https://github.com/falkcorp/github-common/discussions)
 - **Security**: See [SECURITY.md](SECURITY.md) for reporting security issues
 
 ## 🏷️ Versioning

--- a/TODO.md
+++ b/TODO.md
@@ -557,9 +557,10 @@ script.
   and custom labels
 
 **Script Reference:**
-`/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/sync-labels-fast.py`
+`/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/sync-labels-fast.py`
 
-**Labels File:** `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/labels.json`
+**Labels File:**
+`/Users/jdfalk/repos/github.com/falkcorp/github-common/labels.json`
 
 ---
 
@@ -728,7 +729,7 @@ instead of manual Go builds. This is a breaking change requiring v2.0.0.
 5. [ ] Update ghcommon workflows to use v2
 
 **Script:**
-`/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/tag-release-go-v2.sh`
+`/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/tag-release-go-v2.sh`
 
 ---
 
@@ -748,7 +749,7 @@ with version comments for security and reproducibility.
 5. [ ] Update documentation with pinning policy
 
 **Script:**
-`/Users/jdfalk/repos/github.com/jdfalk/ghcommon/scripts/pin-actions-to-hashes.py`
+`/Users/jdfalk/repos/github.com/falkcorp/github-common/scripts/pin-actions-to-hashes.py`
 
 **Output:** `ACTION_VERSIONS.md` - Version/hash reference table
 
@@ -763,17 +764,17 @@ the new jdfalk/\* actions.
 
 **Action Items:**
 
-1. [ ] Update `release-go.yml` to use `jdfalk/release-go-action@hash # v2.0.1`
+1. [ ] Update `release-go.yml` to use `falkcorp/gha-release-go@hash # v2.0.1`
 2. [ ] Update `release-docker.yml` to use
-       `jdfalk/release-docker-action@hash # v1.0.0`
+       `falkcorp/gha-release-docker@hash # v1.0.0`
 3. [ ] Update `release-frontend.yml` to use
-       `jdfalk/release-frontend-action@hash # v1.0.0`
+       `falkcorp/gha-release-frontend@hash # v1.0.0`
 4. [ ] Update `release-python.yml` to use
-       `jdfalk/release-python-action@hash # v1.0.0`
+       `falkcorp/gha-release-python@hash # v1.0.0`
 5. [ ] Update `release-rust.yml` to use
-       `jdfalk/release-rust-action@hash # v1.0.0`
+       `falkcorp/gha-release-rust@hash # v1.0.0`
 6. [ ] Update `release-protobuf.yml` to use
-       `jdfalk/release-protobuf-action@hash # v1.0.0`
+       `falkcorp/gha-release-protobuf-base@hash # v1.0.0`
 7. [ ] Test each workflow conversion
 8. [ ] Document migration for repositories using these workflows
 

--- a/WORKFLOW_CONSOLIDATION_PLAN.md
+++ b/WORKFLOW_CONSOLIDATION_PLAN.md
@@ -559,7 +559,7 @@ For each repository using ghcommon workflows:
 ```yaml
 jobs:
   release:
-    uses: jdfalk/ghcommon/.github/workflows/release-docker.yml@main
+    uses: falkcorp/github-common/.github/workflows/release-docker.yml@main
     with:
       dockerfile: Dockerfile
       platforms: linux/amd64,linux/arm64
@@ -574,7 +574,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdfalk/release-docker-action@v1
+      - uses: falkcorp/gha-release-docker@v1
         with:
           dockerfile: Dockerfile
           platforms: linux/amd64,linux/arm64
@@ -669,7 +669,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdfalk/release-docker-action@v1
+      - uses: falkcorp/gha-release-docker@v1
         with:
           registries: dockerhub,ghcr
         env:
@@ -687,9 +687,9 @@ jobs:
 Use **major version tags** for ease of use:
 
 ```yaml
-uses: jdfalk/release-docker-action@v1  # Tracks latest v1.x.x
-uses: jdfalk/release-docker-action@v1.2  # Tracks latest v1.2.x
-uses: jdfalk/release-docker-action@v1.2.3  # Specific version
+uses: falkcorp/gha-release-docker@v1  # Tracks latest v1.x.x
+uses: falkcorp/gha-release-docker@v1.2  # Tracks latest v1.2.x
+uses: falkcorp/gha-release-docker@v1.2.3  # Specific version
 ```
 
 ## Repository Structure Example

--- a/WORKFLOW_SCRIPT_AUDIT.md
+++ b/WORKFLOW_SCRIPT_AUDIT.md
@@ -330,7 +330,7 @@ remains in scripts.
 
 Based on grep search, these repositories call the reusable workflows:
 
-- `jdfalk/audiobook-organizer` - Uses reusable-ci.yml, reusable-release.yml
+- `falkcorp/audiobook-organizer` - Uses reusable-ci.yml, reusable-release.yml
 - `jdfalk/ghcommon` (self) - Self-referential workflows
 - `jdfalk/project-template` - Template for new repos
 - **Estimate:** 10-50 additional repositories (not in current workspace)
@@ -378,7 +378,7 @@ Based on grep search, these repositories call the reusable workflows:
 
 - A) Continue separate repos (1 action = 1 repo)
 - B) Create `jdfalk/ghcommon-actions` monorepo with multiple actions
-- C) Embed actions in `jdfalk/ghcommon/.github/actions/`
+- C) Embed actions in `falkcorp/github-common/.github/actions/`
 
 **Recommendation:** **Option A (Separate Repos)** for consistency
 

--- a/WORKFLOW_SCRIPT_USAGE_MAP.md
+++ b/WORKFLOW_SCRIPT_USAGE_MAP.md
@@ -62,7 +62,7 @@ fails or the path resolution breaks.
 **✅ Solution:** Replace with action calls:
 
 ```yaml
-- uses: jdfalk/load-config-action@v1
+- uses: falkcorp/gha-load-config@v1
   id: config
   with:
     config-file: .github/repository-config.yml
@@ -99,7 +99,7 @@ scripts)
 - `config` - JSON string of config
 - `has-config` - Boolean flag
 
-**Conversion Target:** `jdfalk/load-config-action@v1`
+**Conversion Target:** `falkcorp/gha-load-config@v1`
 
 ---
 
@@ -139,7 +139,7 @@ scripts)
 - `workflow_common.py` (for write_output)
 - `load_repository_config.py` (indirect via REPOSITORY_CONFIG)
 
-**Conversion Target:** `jdfalk/ci-generate-matrices-action@v1`
+**Conversion Target:** `falkcorp/gha-ci-generate-matrices@v1`
 
 ---
 
@@ -199,7 +199,7 @@ repositories on release tags **Script Dependencies:** CRITICAL (5+ scripts)
 
 **Same as CI workflow** - See above.
 
-**Conversion Target:** `jdfalk/load-config-action@v1`
+**Conversion Target:** `falkcorp/gha-load-config@v1`
 
 ---
 
@@ -251,7 +251,7 @@ generate matrices"
 - `workflow_common.py`
 - File system checks (Path().exists())
 
-**Conversion Target:** `jdfalk/detect-languages-action@v1`
+**Conversion Target:** `falkcorp/gha-detect-languages@v1`
 
 ---
 
@@ -292,7 +292,7 @@ branch"
 
 - `workflow_common.py`
 
-**Conversion Target:** `jdfalk/release-strategy-action@v1`
+**Conversion Target:** `falkcorp/gha-release-strategy@v1`
 
 ---
 
@@ -329,7 +329,7 @@ branch"
 - `workflow_common.py`
 - `git` command (for tag inspection)
 
-**Conversion Target:** `jdfalk/generate-version-action@v1`
+**Conversion Target:** `falkcorp/gha-generate-version@v1`
 
 ---
 
@@ -393,7 +393,7 @@ branch"
 - `assets` - JSON list of packaged assets
 - `checksums` - SHA256 checksums file
 
-**Conversion Target:** `jdfalk/package-assets-action@v1`
+**Conversion Target:** `falkcorp/gha-package-assets@v1`
 
 ---
 
@@ -537,7 +537,7 @@ large script)
 - run: python3 "$GHCOMMON_SCRIPTS_DIR/docs_workflow.py" generate-changelog
 ```
 
-**Conversion Target:** `jdfalk/docs-generator-action@v1` (multi-mode)
+**Conversion Target:** `falkcorp/gha-docs-generator@v1` (multi-mode)
 
 ---
 

--- a/dependency-analysis.md
+++ b/dependency-analysis.md
@@ -62,9 +62,9 @@ All analysis outputs are located in the `dependency-analysis/` directory:
 From the repository root (uses the repo’s virtualenv):
 
 - Full graph with default excludes:
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/.venv/bin/python analyze-dependencies.py --root . --exclude .git,node_modules,.venv --full`
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/.venv/bin/python analyze-dependencies.py --root . --exclude .git,node_modules,.venv --full`
 - Tuned Mermaid limits (example):
-- `/Users/jdfalk/repos/github.com/jdfalk/ghcommon/.venv/bin/python analyze-dependencies.py --root . --mermaid-max-files 500 --mermaid-max-edges 5000`
+- `/Users/jdfalk/repos/github.com/falkcorp/github-common/.venv/bin/python analyze-dependencies.py --root . --mermaid-max-files 500 --mermaid-max-edges 5000`
 
 ## Analysis Progress
 


### PR DESCRIPTION
## Migrate org references: jdfalk → falkcorp

Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags from `jdfalk/` to `falkcorp/` as part of the organization migration. This is the central reusable workflow hub — 35 files updated.

🤖 Generated by `scripts/org-migration/update-workflow-refs.py`