### PR TITLE
fix(ci): replace SC2015 A&&B||C anti-pattern in reusable-burndown

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -217,8 +217,11 @@ jobs:
         run: |
           count=$(jq '.tasks | length' "$RUNNER_TEMP/tasks.json")
           [ "$count" -gt 256 ] && count=256
-          indices=$([ "$count" -eq 0 ] && echo '[]' \
-            || jq -cn --argjson n "$count" '[range(0;$n)]')
+          if [ "$count" -eq 0 ]; then
+            indices='[]'
+          else
+            indices=$(jq -cn --argjson n "$count" '[range(0;$n)]')
+          fi
           echo "task_count=$count"     >> "$GITHUB_OUTPUT"
           echo "task_indices=$indices" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Fixes actionlint SC2015 warning in `reusable-burndown.yml` line 217
- The `[ cond ] && A || B` shell pattern is ambiguous: if `A` exits non-zero, the shell falls through to `B` even when `cond` is true
- Replaced with explicit `if/then/else/fi` which has unambiguous semantics

## Change

```bash
# Before (SC2015 anti-pattern):
indices=$([ "$count" -eq 0 ] && echo '[]' \
  || jq -cn --argjson n "$count" '[range(0;$n)]')

# After (explicit if/then/else):
if [ "$count" -eq 0 ]; then
  indices='[]'
else
  indices=$(jq -cn --argjson n "$count" '[range(0;$n)]')
fi
```

## Test plan
- [ ] CI actionlint check passes on this branch
- [ ] reusable-burndown workflow still emits correct `task_indices` output for empty and non-empty task lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)