### PR TITLE
fix(ci): fix all remaining shellcheck lint failures in reusable workflows

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -217,8 +217,11 @@ jobs:
         run: |
           count=$(jq '.tasks | length' "$RUNNER_TEMP/tasks.json")
           [ "$count" -gt 256 ] && count=256
-          indices=$([ "$count" -eq 0 ] && echo '[]' \
-            || jq -cn --argjson n "$count" '[range(0;$n)]')
+          if [ "$count" -eq 0 ]; then
+            indices='[]'
+          else
+            indices=$(jq -cn --argjson n "$count" '[range(0;$n)]')
+          fi
           echo "task_count=$count"     >> "$GITHUB_OUTPUT"
           echo "task_indices=$indices" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -333,6 +333,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/digest"
           triage_json="$RUNNER_TEMP/triage/tasks.json"
           if [ ! -f "$triage_json" ]; then
+            # shellcheck disable=SC2016
             printf '## Burndown — no tasks dispatched\n\nMode: `%s`. All classified tasks were dry-run-only.\n' \
               "$MODE" > "$RUNNER_TEMP/digest/digest.md"
             exit 0

--- a/.github/workflows/reusable-ci-minimal.yml
+++ b/.github/workflows/reusable-ci-minimal.yml
@@ -83,8 +83,9 @@ jobs:
         if: inputs.system-packages != ''
         env:
           PACKAGES: ${{ inputs.system-packages }}
-        # shellcheck disable=SC2086
-        run: sudo apt-get update && sudo apt-get install -y $PACKAGES
+        run: |
+          # shellcheck disable=SC2086
+          sudo apt-get update && sudo apt-get install -y $PACKAGES
 
       - name: go vet
         run: go vet ./...
@@ -124,8 +125,9 @@ jobs:
         if: inputs.system-packages != ''
         env:
           PACKAGES: ${{ inputs.system-packages }}
-        # shellcheck disable=SC2086
-        run: sudo apt-get update && sudo apt-get install -y $PACKAGES
+        run: |
+          # shellcheck disable=SC2086
+          sudo apt-get update && sudo apt-get install -y $PACKAGES
 
       - name: Test (short, race)
         run: go test -short -race ./...


### PR DESCRIPTION
## Summary

- SC2086: shellcheck-disable YAML comments before `run:` are invisible to shellcheck (they're stripped during script extraction). Moved the `disable` directives **inside** the `run: |` block as shell comments.
- SC2016: added inline disable for the `printf` format string in `reusable-burndown.yml` where backticks are intentional markdown syntax, not shell variable references.

## Files changed

| File | Issue | Fix |
|------|-------|-----|
| `reusable-ci-minimal.yml:87` | SC2086 YAML comment not seen by shellcheck | Move disable inside `run:` block |
| `reusable-ci-minimal.yml:128` | SC2086 same | Move disable inside `run:` block |
| `reusable-burndown.yml:332` | SC2016 backtick in printf string | Add inline `# shellcheck disable=SC2016` |

## Test plan
- [ ] CI Workflow Lint job passes (no actionlint errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)