### PR TITLE
fix: add GHCR credentials to container jobs for private image pull

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -157,6 +157,9 @@ jobs:
     timeout-minutes: 15
     container:
       image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
     outputs:
       task_indices: ${{ steps.emit.outputs.task_indices }}
       task_count: ${{ steps.emit.outputs.task_count }}
@@ -236,6 +239,9 @@ jobs:
     timeout-minutes: 45
     container:
       image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -308,6 +314,9 @@ jobs:
     timeout-minutes: 10
     container:
       image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
     steps:
       - name: Download triage artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -374,6 +383,9 @@ jobs:
     timeout-minutes: 15
     container:
       image: ghcr.io/falkcorp/burndown-runner-image:483ee343bc56a4ceec28180b336409a96bb56400
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
     steps:
       - name: Create GitHub App token
         id: app-token


### PR DESCRIPTION
Org-level policy blocks making `burndown-runner-image` public. Added explicit `credentials` to all four container jobs in `reusable-burndown.yml` using `JF_CI_GH_PAT` (inherited via `secrets: inherit`) with `GITHUB_TOKEN` fallback.