### PR TITLE
chore: update burndown-runner-image to ob-77dfdfa

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-burndown.yml
-# version: 1.9.0
+# version: 1.10.0
 # Reusable per-repo burndown workflow — lives in ghcommon, called from every repo.
 #
 # Usage:
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:09a419b207b3e81874151c543a8aad08db224c9e
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:09a419b207b3e81874151c543a8aad08db224c9e
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:09a419b207b3e81874151c543a8aad08db224c9e
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -388,7 +388,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:09a419b207b3e81874151c543a8aad08db224c9e
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Updates all 4 `container: image:` pins in `reusable-burndown.yml` from the raw `burndown-runner-image` git SHA to the new semantic `ob-77dfdfa` tag
- `ob-77dfdfa` = image containing `overnight-burndown@77dfdfa`

## What ob- tags mean

Introduced in [falkcorp/burndown-runner-image#16](https://github.com/falkcorp/burndown-runner-image/pull/16): the image is tagged `ob-<sha7>` where the SHA identifies the **overnight-burndown binary** inside — not the runner-image repo SHA. This makes the tag immutable, semantic, and rollback-safe.

## Going forward

The `retag` job in `burndown-runner-image/release.yml` will auto-open a PR here after every image build once `JF_CI_GH_PAT` is added to `burndown-runner-image` repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)