### PR TITLE
chore: update burndown-runner-image to ob-77dfdfa

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -14,7 +14,7 @@
 # Exits early if none found. Otherwise: triage → dispatch (matrix) → aggregate.
 #
 # The burndown binary is pre-baked into
-# ghcr.io/falkcorp/burndown-runner-image:bootstrap at /usr/local/bin/burndown.
+# ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa at /usr/local/bin/burndown.
 # Config is driven entirely by environment variables — no config.yaml needed.
 
 name: Burndown (reusable)


### PR DESCRIPTION
Automatic update from burndown-runner-image build.

New image tag: `ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa`
Contains overnight-burndown@77dfdfafdd25f7f21ccca537b78eedc2fc0f7c8d

**Lines changed:** 3
**Auto-merged:** true

---
🤖 Generated by the Build image workflow