### PR TITLE
docs: rewrite README (concise + burndown diagrams), add CHANGELOG v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+## [v1.11.0] — 2026-06-09
+
+### Added
+
+#### `reusable-burndown.yml` — `rebase-stale` job for automatic PR conflict resolution
+
+New `rebase-stale` job runs in parallel with `preflight` at the start of every
+burndown run. It finds all open `automation`-labeled PRs where GitHub reports
+`mergeable == CONFLICTING`, rebases each onto `main`, and force-pushes:
+
+- Clean rebase → force-push, remove `status:conflict-unresolvable` label if
+  present
+- Conflict → `git rebase --abort`, add `status:conflict-unresolvable` label,
+  post comment: "close and re-dispatch to regenerate from current `main`"
+- `triage` now `needs: [preflight, rebase-stale]` so dispatch always starts from
+  a post-rebase base
+- `continue-on-error: true` on the rebase step: git errors never block new
+  dispatch
+
+New label created automatically: `status:conflict-unresolvable` (`#b60205` red).
+
+README rewritten to be concise (removed duplicated bloat, moved detail to
+CHANGELOG).
+
+## [v1.10.0] — 2026-06-02
+
+### Added
+
+- `max_tasks` input to cap dispatched tasks per run (prevents OpenAI 429 on
+  large queues)
+- Scheduled runs in calling repos now use `full` mode (auto-merge) via
+  caller-side condition
+
+## [v1.9.0] — (prior)
+
 ### Completed
 
 #### January 10, 2026 - Docker Rollout Across Action Repositories

--- a/README.md
+++ b/README.md
@@ -1,479 +1,131 @@
 <!-- file: README.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 1eaf4c01-aed3-438a-8df9-6904adba092c -->
-<!-- last-edited: 2026-01-19 -->
+<!-- last-edited: 2026-06-09 -->
 
 # GitHub Common Workflows
 
 [![Continuous Integration](https://github.com/falkcorp/github-common/actions/workflows/ci.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/ci.yml)
-[![CI Self Tests](https://github.com/falkcorp/github-common/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/ci-tests.yml)
-[![CodeQL](https://github.com/falkcorp/github-common/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/github-code-scanning/codeql)
 [![Security Scans](https://github.com/falkcorp/github-common/actions/workflows/security.yml/badge.svg)](https://github.com/falkcorp/github-common/actions/workflows/security.yml)
 
-## Table of Contents
+Shared GitHub Actions workflows for all `falkcorp/*` repositories. Call with
+`uses:` and pin to a full SHA.
 
-- [GitHub Common Workflows](#github-common-workflows)
-  - [Table of Contents](#table-of-contents)
-  - [🚀 Quick Start](#-quick-start)
-    - [For Complete CI/CD Pipeline](#for-complete-cicd-pipeline)
-    - [For Container-Only Projects](#for-container-only-projects)
-    - [For Library/Package Projects](#for-librarypackage-projects)
-  - [📋 What's Included](#-whats-included)
-    - [Reusable Workflows](#reusable-workflows)
-    - [Templates](#templates)
-    - [Supporting Tools](#supporting-tools)
-  - [🔧 Core Features](#-core-features)
-    - [Semantic Versioning](#semantic-versioning)
-    - [Multi-Architecture Container Builds](#multi-architecture-container-builds)
-    - [Automated Releases](#automated-releases)
-    - [Issue Management](#issue-management)
-    - [Label Synchronization](#label-synchronization)
-  - [📖 Usage Examples](#-usage-examples)
-    - [Basic Semantic Versioning](#basic-semantic-versioning)
-    - [Multi-Arch Container Build](#multi-arch-container-build)
-    - [Automatic Release](#automatic-release)
-    - [Issue Management Workflow](#issue-management-workflow)
-    - [Label Synchronization Workflow](#label-synchronization-workflow)
-  - [🛡️ Security Features](#️-security-features)
-  - [🔒 Requirements](#-requirements)
-    - [Repository Permissions](#repository-permissions)
-    - [Required Secrets (Optional)](#required-secrets-optional)
-  - [📚 Documentation](#-documentation)
-    - [Setup Guides](#setup-guides)
-    - [Templates](#templates-1)
-  - [🚦 Validation](#-validation)
-  - [🤝 Contributing](#-contributing)
-    - [Development Setup](#development-setup)
-  - [📄 License](#-license)
-  - [🆘 Support](#-support)
-  - [🏷️ Versioning](#️-versioning)
-  - [🙏 Acknowledgments](#-acknowledgments)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase-1)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase-2)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase-3)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase-4)
-  - [AI Rebase Improvements\\n- Workflow now auto-merges PRs after successful rebase](#ai-rebase-improvementsn--workflow-now-auto-merges-prs-after-successful-rebase-5)
-  - [Protobuf Definitions](#protobuf-definitions)
-  - [Queue Module](#queue-module)
-- [Queue Module](#queue-module-1)
-  - [Queue Module\\n\\nTODO: Add content for this section](#queue-modulenntodo-add-content-for-this-section)
-- [Protobuf Definitions](#protobuf-definitions-1)
-  - [Protobuf Definitions\\n\\n*Moved to gcommon repository.*](#protobuf-definitionsnnmoved-to-gcommon-repository)
+## Reusable Workflows
 
-## 🚀 Quick Start
+| Workflow                                                                                           | Purpose                                                                  |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`reusable-ci.yml`](.github/workflows/reusable-ci.yml)                                             | Full CI: lint, test, build (Go + Node)                                   |
+| [`reusable-ci-minimal.yml`](.github/workflows/reusable-ci-minimal.yml)                             | CI without frontend steps                                                |
+| [`reusable-burndown.yml`](.github/workflows/reusable-burndown.yml)                                 | AI agent task dispatch — triage → dispatch matrix → auto-rebase → digest |
+| [`reusable-release.yml`](.github/workflows/reusable-release.yml)                                   | Semantic versioning + GitHub release                                     |
+| [`reusable-security.yml`](.github/workflows/reusable-security.yml)                                 | CodeQL + Trivy + OSV scanning                                            |
+| [`reusable-triage-poll.yml`](.github/workflows/reusable-triage-poll.yml)                           | Poll burndown hub for new ready tasks                                    |
+| [`reusable-maintenance.yml`](.github/workflows/reusable-maintenance.yml)                           | Stale issue cleanup, label sync                                          |
+| [`reusable-unified-issue-management.yml`](.github/workflows/reusable-unified-issue-management.yml) | JSON-driven issue updates, Copilot tickets, dedup                        |
 
-Choose the setup that matches your project type:
+## 🤖 Burndown Bot (`reusable-burndown.yml`)
 
-### For Complete CI/CD Pipeline
+Fully automated AI agent dispatch. Each calling repo has a hub repo (GitHub
+Issues as task specs). The workflow fans out AI agents to implement tasks and
+open PRs — then cleans up any stale conflicting PRs automatically before each
+run.
 
-```bash
-curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s complete
+### Full run flow
+
+```mermaid
+flowchart TD
+    trigger([Schedule or workflow_dispatch]) --> preflight & rebase_stale
+
+    subgraph phase1["Phase 1 — parallel startup (no AI cost)"]
+        preflight["preflight\nCount ready tasks\nin hub repo via App JWT"]
+        rebase_stale["rebase-stale\nFind open CONFLICTING bot PRs\n→ git rebase origin/main\n→ force-push or label unresolvable"]
+    end
+
+    preflight -->|has_tasks=false| done_early([Exit — nothing to do])
+    preflight -->|has_tasks=true| triage
+    rebase_stale --> triage
+
+    triage["triage\nAI classifies tasks\nbuilds dispatch matrix\n(respects max_tasks cap)"]
+    triage --> dispatch
+
+    subgraph phase3["Phase 3 — matrix fan-out (AI cost)"]
+        dispatch["dispatch ×N\nAgent reads code, writes fix/tests\nopens PR via App token"]
+    end
+
+    dispatch --> aggregate["aggregate\nCollect outcomes\npost job summary"]
+    aggregate --> decompose{"task_filter\n== failed-batch?"}
+    decompose -->|yes| decompose_job["decompose\nClaude Haiku splits hard tasks\ninto subtasks → PR to TODO.md"]
+    decompose -->|no| finish([Done])
+    decompose_job --> finish
 ```
 
-### For Container-Only Projects
+### Conflict resolution — rebase-stale
 
-```bash
-curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s container
+When `main` advances past a bot PR's base, GitHub marks it `CONFLICTING`. The
+`rebase-stale` job resolves this before every triage:
+
+```mermaid
+flowchart LR
+    find["gh pr list\nautomation label\nmergeable=CONFLICTING"] --> loop
+
+    subgraph loop["for each conflicting PR"]
+        fetch["git fetch origin branch"] --> rb["git rebase origin/main"]
+        rb -->|clean| push["force-push\norigin HEAD:branch\nremove conflict label"]
+        rb -->|conflicts| abort["git rebase --abort\nadd status:conflict-unresolvable\npost comment: close + re-dispatch"]
+    end
 ```
 
-### For Library/Package Projects
+### Inputs
 
-```bash
-curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/setup-repository.sh | bash -s library
-```
+| Input           | Default                   | Description                                              |
+| --------------- | ------------------------- | -------------------------------------------------------- |
+| `mode`          | `dry-run`                 | `dry-run` \| `draft-only` \| `full` (auto-merges PRs)    |
+| `hub_repo`      | `falkcorp/burndown-tasks` | GitHub repo holding task issues                          |
+| `triage_model`  | `o4-mini`                 | OpenAI model for triage                                  |
+| `cheapest_only` | `false`                   | Skip model tier escalation                               |
+| `max_tasks`     | `0` (unlimited)           | Cap dispatched tasks per run                             |
+| `task_filter`   | `""`                      | `""` = normal \| `"failed-batch"` = hard run + decompose |
 
-## 📋 What's Included
+### Required secrets
 
-### Reusable Workflows
+`BURNDOWN_BOT_APP_ID`, `BURNDOWN_BOT_INSTALLATION_ID`,
+`BURNDOWN_BOT_PRIVATE_KEY`,  
+`BURNDOWN_BOT_OPENAI_API_KEY` (or `BURNDOWN_BOT_CLAUDE_API_KEY`)
 
-| Workflow                                                                                  | Purpose                                       | Key Features                                                        |
-| ----------------------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [`reusable-semantic-versioning.yml`](.github/workflows/reusable-semantic-versioning.yml)  | Automatic version calculation                 | Conventional commits, PR title updates, version file updates        |
-| [`reusable-super-linter.yml`](.github/workflows/reusable-super-linter.yml)                | Comprehensive code linting                    | Multi-language linting, style enforcement, security scanning        |
-| [`buildah-multiarch.yml`](.github/workflows/buildah-multiarch.yml)                        | Multi-arch container builds                   | SBOM generation, vulnerability scanning, attestation, signing       |
-| [`automatic-release.yml`](.github/workflows/automatic-release.yml)                        | Automated GitHub releases                     | Release notes, artifact management, notifications                   |
-| [`unified-issue-management.yml`](.github/workflows/reusable-unified-issue-management.yml) | Comprehensive issue management                |
-| [`reusable-unified-automation.yml`](.github/workflows/reusable-unified-automation.yml)    | Unified automation orchestrator               | Runs issue management, docs update, labeler, linting, and AI rebase |
-| [`unified-automation.yml`](.github/workflows/unified-automation.yml)                      | Standalone workflow to run unified automation | Manual trigger with extensive options                               | JSON-driven updates, Copilot tickets, duplicate closure, security alerts |
-| [`reusable-unified-automation.yml`](.github/workflows/reusable-unified-automation.yml)    | Unified automation orchestrator               | Runs issue management, docs update, labeler, linting, and AI rebase |
-| [`unified-automation.yml`](.github/workflows/unified-automation.yml)                      | Standalone workflow to run unified automation | Manual trigger with extensive options                               |
-
-### Templates
-
-| Template                                                         | Description                | Use Case                                   |
-| ---------------------------------------------------------------- | -------------------------- | ------------------------------------------ |
-| [`complete-ci-cd.yml`](templates/workflows/complete-ci-cd.yml)   | Full CI/CD pipeline        | Full-stack applications, microservices     |
-| [`container-only.yml`](templates/workflows/container-only.yml)   | Container-focused pipeline | Containerized applications, Docker images  |
-| [`library-release.yml`](templates/workflows/library-release.yml) | Package release pipeline   | NPM packages, Python libraries, Go modules |
-
-### Supporting Tools
-
-- **Enhanced Documentation Update System**: Comprehensive JSON-driven
-  documentation update workflow with templates, automation, and conflict
-  resolution\n - Advanced Python script with multiple update modes and
-  templates\n - Automated workflow processing with PR creation and archival\n -
-  Support for changelogs, TODO lists, README sections, and badge updates\n -
-  Interactive mode and dry-run capabilities for safe operations\n - Complete
-  documentation and usage examples in
-  [docs/documentation-updates.md](docs/documentation-updates.md)
-
-- **Setup Scripts**: Automated repository configuration
-- **Project Automation**: Script to create GitHub Projects via CLI
-- GitHub Projects automation now uses built-in features. Custom add-to-project
-  workflows have been removed.
-- **Project Automation**: Script to create GitHub Projects via CLI
-- GitHub Projects automation now uses built-in features. Custom add-to-project
-  workflows have been removed.
-- GitHub Projects automation now uses built-in features. Custom add-to-project
-  workflows have been removed.
-- **Project Automation**: Script to create GitHub Projects via CLI
-- GitHub Projects automation now uses built-in features. Custom add-to-project
-  workflows have been removed.
-- GitHub Projects automation now uses built-in features. Custom add-to-project
-  workflows have been removed.
-- **Validation Tools**: Repository readiness verification
-- **Copilot Instructions**: AI-assisted workflow implementation
-- **Security Guidelines**: Best practices and compliance
-- **Advanced CodeQL Configuration**: Centralized config with automatic language
-  detection
-- **Advanced CodeQL Configuration**: Centralized config with automatic language
-  detection
-- **Advanced CodeQL Configuration**: Centralized config with automatic language
-  detection
-- **Advanced CodeQL Configuration**: Centralized config with automatic language
-  detection
-
-## 🔧 Core Features
-
-### Semantic Versioning
-
-- **Automatic version calculation** based on conventional commits
-- **Multi-file version updates** (package.json, version.txt, etc.)
-- **PR title enhancement** with conventional commit prefixes
-- **Dry-run support** for testing
-
-### Multi-Architecture Container Builds
-
-- **Cross-platform builds** (linux/amd64, linux/arm64, linux/arm/v7)
-- **Security-first approach** with Buildah
-- **SBOM generation** with Syft
-- **Vulnerability scanning** with Grype
-- **Image signing** and attestation with Cosign
-- **Comprehensive artifact management**
-
-### Automated Releases
-
-- **Smart version detection** from commit messages
-- **Automated release notes** from conventional commits
-- **Artifact collection** and attachment
-- **Security attestations** for releases
-- **Slack/Teams notifications**
-- **Container image integration**
-
-### Issue Management
-
-- **Comprehensive issue tracking** with GitHub Issues
-- **Automated ticket creation** from PRs and commits
-- **Duplicate issue detection** and closure
-- **Security vulnerability alerts** integration
-- **Distributed file processing** with automatic archival
-- **Conflict-free parallel development** using GUID-based updates
-
-### Label Synchronization
-
-- **Centralized label management** across multiple repositories
-- **Standard label configuration** with consistent colors and descriptions
-- **Automated sync scheduling** with customizable frequency
-- **Safe mode** (no deletions) and cleanup mode support
-- **Dry-run testing** before applying changes
-- **Batch repository processing** from configuration files
-
-## 📖 Usage Examples
-
-### Basic Semantic Versioning
+### Caller example
 
 ```yaml
-versioning:
-  uses: falkcorp/github-common/.github/workflows/reusable-semantic-versioning.yml@main
-  with:
-    version-files: '["package.json", "version.txt"]'
-    update-pr-title: true
-    dry-run: ${{ github.event_name == 'pull_request' }}
-```
-
-### Multi-Arch Container Build
-
-```yaml
-container:
-  uses: falkcorp/github-common/.github/workflows/buildah-multiarch.yml@main
-  with:
-    image-name: my-app
-    platforms: linux/amd64,linux/arm64
-    generate-sbom: true
-    generate-attestation: true
-    scan-vulnerability: true
-```
-
-### Automatic Release
-
-```yaml
-release:
-  uses: falkcorp/github-common/.github/workflows/automatic-release.yml@main
-  with:
-    release-type: auto
-    include-artifacts: true
-    container-image: ${{ needs.container.outputs.image-url }}
-```
-
-### Issue Management Workflow
-
-```yaml
-name: Issue Management
-
-on:
-  push:
-    branches: [main]
-    paths:
-      - 'issue_updates.json'
-      - '.github/issue-updates/*.json'
-  pull_request_review_comment:
-    types: [created, edited, deleted]
-  schedule:
-    - cron: '0 2 * * *' # Daily maintenance
-  workflow_dispatch:
-
+# .github/workflows/nightly-burndown.yml
 jobs:
-  issue-management:
-    uses: falkcorp/github-common/.github/workflows/reusable-unified-issue-management.yml@main
+  burndown:
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@<SHA> # vX.Y.Z
     with:
-      operations: 'auto' # Auto-detect based on event
-      issue_updates_file: 'issue_updates.json'
-      issue_updates_directory: '.github/issue-updates'
-      cleanup_issue_updates: true
+      # Scheduled runs auto-merge; manual dispatch defaults to draft-only for safety
+      mode:
+        ${{ github.event_name == 'schedule' && 'full' || inputs.mode ||
+        'draft-only' }}
+      hub_repo: falkcorp/burndown-tasks
+      cheapest_only: true
+      triage_model: gpt-4.1
+      max_tasks:
+        ${{ github.event_name == 'schedule' && 8 || fromJSON(inputs.max_tasks ||
+        '0') }}
     secrets: inherit
 ```
 
-### Label Synchronization Workflow
+> **Always pin to a full commit SHA, never a tag.** Use
+> `@<40-char-sha> # vX.Y.Z`.
 
-```yaml
-name: Sync Labels from ghcommon
+## Requirements
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 3 1 * *' # Monthly on 1st at 3 AM UTC
+- GitHub App with `contents:write`, `pull-requests:write`, `issues:write` on
+  target repos
+- All `uses:` references must be SHA-pinned (enforced by pre-commit hooks)
 
-jobs:
-  sync-labels:
-    uses: falkcorp/github-common/.github/workflows/reusable-label-sync.yml@main
-    with:
-      repositories: ${{ github.repository }}
-      source-repo: 'jdfalk/ghcommon'
-      delete-extra-labels: false # Safe mode
-    secrets: inherit
-```
+## See also
 
-````
-
-**Features**:
-
-- JSON-driven issue updates (legacy and distributed formats)
-- Copilot review comment tickets
-- Duplicate issue detection and closure
-- CodeQL security alert integration
-- GUID-based duplicate prevention
-- Parallel development with no merge conflicts
-- **Automatic PR creation** for processed file archival
-- **Workflow summary reports** with detailed operation status
-
-**Helper Script**: Copy the issue creation helper to your repository:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/create-issue-update.sh -o scripts/create-issue-update.sh
-chmod +x scripts/create-issue-update.sh
-
-# Usage examples:
-./scripts/create-issue-update.sh create "Add dark mode" "Implement dark theme" "enhancement,ui"
-./scripts/create-issue-update.sh comment 123 "Testing completed successfully"
-````
-
-**Documentation**:
-[docs/unified-issue-management.md](docs/unified-issue-management.md)
-**Documentation**: [docs/unified-automation.md](docs/unified-automation.md)
-**Examples**: [examples/workflows/](examples/workflows/)
-
-## 🛡️ Security Features
-
-- **Supply chain security** with SBOMs and attestations
-- **Vulnerability scanning** for containers and dependencies
-- **Image signing** with Cosign and keyless signing
-- **Least privilege access** patterns
-- **Secret management** best practices
-- **Compliance-ready** documentation and controls
-
-## 🔒 Requirements
-
-### Repository Permissions
-
-- **Actions**: Read and write permissions
-- **Packages**: Write permissions (for container registries)
-- **Contents**: Write permissions (for releases and tags)
-- **Pull Requests**: Write permissions (for PR updates)
-
-### Required Secrets (Optional)
-
-- `SLACK_WEBHOOK_URL` - For release notifications
-- `TEAMS_WEBHOOK_URL` - For Teams notifications
-- External registry credentials (if not using GitHub Container Registry)
-
-## 📚 Documentation
-
-### Setup Guides
-
-- [Repository Setup Guide](.github/repository-setup.md) - Complete setup
-  instructions
-- [Security Guidelines](.github/security-guidelines.md) - Security best
-  practices
-- [Workflow Usage](.github/workflow-usage.md) - Detailed workflow documentation
-
-### Templates
-
-- [Complete CI/CD](templates/workflows/complete-ci-cd.yml) - Full pipeline
-  template
-- [Container Only](templates/workflows/container-only.yml) - Container-focused
-  template
-- [Library Release](templates/workflows/library-release.yml) - Package release
-  template
-
-## 🚦 Validation
-
-Validate your repository setup:
-
-```bash
-curl -sSL https://raw.githubusercontent.com/falkcorp/github-common/main/scripts/validate-setup.sh | bash
-```
-
-This will check:
-
-- ✅ Workflow file syntax
-- ✅ Required files and structure
-- ✅ Git configuration
-- ✅ Conventional commit usage
-- ✅ Security best practices
-
-## 🤝 Contributing
-
-We welcome contributions! Please see our
-[Contributing Guidelines](CONTRIBUTING.md) for details.
-
-### Development Setup
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test with the validation script
-5. Submit a pull request
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
-for details.
-
-## 🆘 Support
-
-- **Issues**: [GitHub Issues](https://github.com/falkcorp/github-common/issues)
-- **Discussions**:
-  [GitHub Discussions](https://github.com/falkcorp/github-common/discussions)
-- **Security**: See [SECURITY.md](SECURITY.md) for reporting security issues
-
-## 🏷️ Versioning
-
-This project uses [Semantic Versioning](https://semver.org/). See
-[CHANGELOG.md](CHANGELOG.md) for version history.
-
-## 🙏 Acknowledgments
-
-- GitHub Actions team for the platform
-- [Buildah](https://buildah.io/) for secure container builds
-- [Syft](https://github.com/anchore/syft) for SBOM generation
-- [Grype](https://github.com/anchore/grype) for vulnerability scanning
-- [Cosign](https://github.com/sigstore/cosign) for container signing
-- [Conventional Commits](https://www.conventionalcommits.org/) for commit
-  standards
-
-Automation note added Document built-in automation This repository now relies on
-GitHub's built-in project automation. Final automation note Builtin project
-automation documented
-
-Doc update manager now supports `--ignore-errors` to continue processing even if
-an update fails. Automation note added Document built-in automation This
-repository now relies on GitHub's built-in project automation. Final automation
-note Builtin project automation documented
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Automation note added Document built-in automation This repository now relies on
-GitHub's built-in project automation. Final automation note Builtin project
-automation documented
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Automation note added Document built-in automation Added stale issue management
-workflow This repository now relies on GitHub's built-in project automation.
-Final automation note Builtin project automation documented
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Automation note added Document built-in automation Added stale issue management
-workflow This repository now relies on GitHub's built-in project automation.
-Final automation note Builtin project automation documented
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Automation note added Document built-in automation Added stale issue management
-workflow This repository now relies on GitHub's built-in project automation.
-Final automation note Document shared AI rebase system prompt Builtin project
-automation documented
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Added stale issue management workflow Document shared AI rebase system prompt
-
-- AI rebase workflow now uses file-based prompts for model inference
-
-## AI Rebase Improvements\n- Workflow now auto-merges PRs after successful rebase
-
-Fix doc update workflow syntax error Unified automation workflow can now be run
-manually via the Actions tab Added stale issue management workflow Document
-shared AI rebase system prompt Added auto-commit and push in rebase script
-
-## Protobuf Definitions
-
-Added logging protobuf definitions in proto/gcommon/v1
-
-## Queue Module
-
-TODO: Add content for this section
-
-Added cache service protobuf definitions
-
-# Queue Module
-
-## Queue Module\n\nTODO: Add content for this section
-
-# Protobuf Definitions
-
-## Protobuf Definitions\n\n*Moved to gcommon repository.*
-
-- **Reusable CodeQL Workflow**: Unique caching keys prevent collisions
+- [CHANGELOG.md](CHANGELOG.md) — version history and recent changes
+- [TODO.md](TODO.md) — planned work and backlog
+- [CONTRIBUTING.md](CONTRIBUTING.md) — development setup and PR guidelines
+- [SECURITY.md](SECURITY.md) — vulnerability reporting


### PR DESCRIPTION
Cleans up 400 lines of garbage bot-appended content. README is now concise with a Reusable Workflows table and a full Burndown Bot section including two Mermaid flow diagrams. CHANGELOG gains v1.11.0 and v1.10.0 entries. 🤖 Generated with [Claude Code](https://claude.com/claude-code)