### PR TITLE
fix(reusable-burndown): declare JF_CI_GH_PAT in workflow_call secrets

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-burndown.yml
-# version: 1.11.0
+# version: 1.11.1
 # Reusable per-repo burndown workflow — lives in ghcommon, called from every repo.
 #
 # Usage:
@@ -68,6 +68,8 @@ on:
       BURNDOWN_BOT_CLAUDE_API_KEY:
         required: false
       BURNDOWN_BOT_OPENAI_API_KEY:
+        required: false
+      JF_CI_GH_PAT:
         required: false
 
 permissions:


### PR DESCRIPTION
## Problem

`secrets.JF_CI_GH_PAT` is referenced in 4 container credential blocks but not declared in `on.workflow_call.secrets`. GitHub validates reusable workflow secrets at parse time, so callers (e.g. `nightly-burndown.yml`) fail with 'workflow file issue'.

## Fix

Add `JF_CI_GH_PAT: required: false` to the secrets block. `actionlint` passes cleanly after this change.