### PR TITLE
chore: update burndown-runner-image to ob-18f0014

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -14,7 +14,7 @@
 # Exits early if none found. Otherwise: triage → dispatch (matrix) → aggregate.
 #
 # The burndown binary is pre-baked into
-# ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa at /usr/local/bin/burndown.
+# ghcr.io/falkcorp/burndown-runner-image:ob-18f0014 at /usr/local/bin/burndown.
 # Config is driven entirely by environment variables — no config.yaml needed.
 
 name: Burndown (reusable)
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-18f0014
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-18f0014
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -412,7 +412,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-18f0014
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -481,7 +481,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-77dfdfa
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-18f0014
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatic update from burndown-runner-image build.

New image tag: `ghcr.io/falkcorp/burndown-runner-image:ob-18f0014`
Contains overnight-burndown@18f0014f159d22e2663483b8087c38772411d9c8

**Lines changed:** 11
**Auto-merged:** true

---
🤖 Generated by the Build image workflow