### PR TITLE
chore: update burndown-runner-image to ob-0618d75

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -14,7 +14,7 @@
 # Exits early if none found. Otherwise: triage → dispatch (matrix) → aggregate.
 #
 # The burndown binary is pre-baked into
-# ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3 at /usr/local/bin/burndown.
+# ghcr.io/falkcorp/burndown-runner-image:ob-0618d75 at /usr/local/bin/burndown.
 # Config is driven entirely by environment variables — no config.yaml needed.
 
 name: Burndown (reusable)
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-0618d75
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-0618d75
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-0618d75
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -484,7 +484,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-0618d75
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-triage-poll.yml
+++ b/.github/workflows/reusable-triage-poll.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-20cdfe3
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-0618d75
     steps:
       - name: Materialize App key
         env:


### PR DESCRIPTION
Automatic update from burndown-runner-image build.

New image tag: `ghcr.io/falkcorp/burndown-runner-image:ob-0618d75`
Contains overnight-burndown@0618d75e2c15c65816c68215bc2a1e56e92779ce

**Lines changed:** 14
**Auto-merged:** true

---
🤖 Generated by the Build image workflow