### PR TITLE
feat(release): add go-run-linters passthrough to reusable-release.yml

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.13.4
+# version: 2.14.0
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -77,6 +77,11 @@ on:
         required: false
         type: string
         default: ''
+      go-run-linters:
+        description: 'Whether to run go vet/golangci-lint before the Go release build (redundant with CI on most repos)'
+        required: false
+        type: boolean
+        default: true
       stable:
         description: 'Create a stable (non-RC) release directly, bypassing the pre-release flow'
         required: false
@@ -357,6 +362,7 @@ jobs:
           system-packages: ${{ inputs.system-packages }}
           pre-build-script: ${{ inputs.pre-build-script }}
           go-experiment: ${{ inputs.go-experiment }}
+          run-linters: ${{ inputs.go-run-linters }}
           github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
   # Python Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+#### `reusable-release.yml` — `go-run-linters` input forwards to `gha-release-go`'s `run-linters`
+
+Consumer repos whose Go code requires a `GOEXPERIMENT` value (e.g. `jsonv2`)
+could set `go-experiment` but had no way to skip the release workflow's
+redundant `go vet` pass — `gha-release-go`'s lint step doesn't currently set
+`GOEXPERIMENT` from its `go-experiment` input, so any repo relying on that
+experiment fails `go vet` on every release even though CI already vetted the
+same commit correctly. Added `go-run-linters` (default `true`, preserves
+existing behavior) so callers can pass `go-run-linters: false` until the root
+cause is fixed upstream in `gha-release-go`.
+
 ### Fixed
 
 #### `reusable-triage-poll.yml` — re-pinned to a valid image tag; auto-updater now covers it too


### PR DESCRIPTION
## Summary
- `gha-release-go`'s lint step (`go vet ./...`) doesn't set `GOEXPERIMENT` from its `go-experiment` input, so any repo requiring a `GOEXPERIMENT` value (e.g. `jsonv2`) fails release-time `go vet` even though the same commit was already vetted correctly by CI.
- Adds a `go-run-linters` input (default `true`, no behavior change for existing callers) and forwards it as `run-linters` to `gha-release-go`, so affected repos can opt out of the redundant release-time vet until the root cause is fixed upstream in `gha-release-go`.

## Test plan
- [ ] `audiobook-organizer`'s `release-prod.yml` sets `go-run-linters: false` after this merges, and a `workflow_dispatch` release run completes past the Go build job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT