### PR TITLE
fix(release): update ghcommon workflow-scripts checkout to falkcorp/github-common

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.0
+# version: 2.14.1
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -484,7 +484,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
-          repository: jdfalk/ghcommon
+          repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
           sparse-checkout: |
@@ -784,7 +784,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
-          repository: jdfalk/ghcommon
+          repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
           sparse-checkout: |
@@ -955,7 +955,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
-          repository: jdfalk/ghcommon
+          repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           sparse-checkout: |
             .github/workflows/scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+#### `reusable-release.yml` — ghcommon workflow-scripts checkout pointed at the pre-migration `jdfalk/ghcommon` repo
+
+All three "Checkout ghcommon workflow scripts" steps hardcoded
+`repository: jdfalk/ghcommon`, which stopped existing once this repo moved to
+`falkcorp/github-common` — every release/prerelease run's "Create GitHub
+Release" job failed with
+`unable to access 'https://github.com/jdfalk/ghcommon/': The requested URL returned error: 400`.
+Updated all three to `repository: falkcorp/github-common`.
+
 ### Added
 
 #### `reusable-release.yml` — `go-run-linters` input forwards to `gha-release-go`'s `run-linters`


### PR DESCRIPTION
## Summary
- All three "Checkout ghcommon workflow scripts" steps in `reusable-release.yml` hardcoded `repository: jdfalk/ghcommon`, which no longer exists after the org migration to `falkcorp/github-common`.
- Every release/prerelease run's "Create GitHub Release" job failed with `unable to access 'https://github.com/jdfalk/ghcommon/': The requested URL returned error: 400`.
- Updated all three occurrences to `repository: falkcorp/github-common`.

## Test plan
- [ ] Merge, bump the pin in `audiobook-organizer`'s `release-prod.yml`/`prerelease.yml`, and confirm "Create GitHub Release" succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT