### PR TITLE
fix(release): pin ghcommon-scripts checkout ref instead of live resolution

### DIFF
--- a/.github/ghcommon-ref.txt
+++ b/.github/ghcommon-ref.txt
@@ -1,0 +1,1 @@
+e44a03f9da7de181d31fc05e173a3a1ddaeda941

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.1
+# version: 2.14.2
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -474,11 +474,11 @@ jobs:
       - name: Determine ghcommon workflow ref
         id: ghcommon-ref
         run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          if [[ -z "$ref" || "$ref" == "$GITHUB_WORKFLOW_REF" ]]; then
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+          if [ -f .github/ghcommon-ref.txt ]; then
+            echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
           fi
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -774,11 +774,11 @@ jobs:
       - name: Determine ghcommon workflow ref
         id: ghcommon-ref
         run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          if [[ -z "$ref" || "$ref" == "$GITHUB_WORKFLOW_REF" ]]; then
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+          if [ -f .github/ghcommon-ref.txt ]; then
+            echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
           fi
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Fixed
 
+#### `reusable-release.yml` — ghcommon-scripts checkout used a live ref lookup that hit a GitHub Actions-side stale-resolution bug
+
+Two of the three "Determine ghcommon workflow ref" steps derived the ref via
+`${GITHUB_WORKFLOW_REF##*@}`, which in a reusable-workflow context extracts the
+_calling_ repo's ref (e.g. `refs/heads/main`) rather than a ref specific to
+`falkcorp/github-common`. That value happens to also be a valid branch name in
+`github-common`, so it looked correct — but `actions/checkout`'s resolution of
+`refs/heads/main` for this specific (recently renamed) repo consistently
+returned a commit SHA that doesn't exist in either repo, reproducibly failing
+every release with `fatal: could not fetch <sha> from promisor remote` even
+though `git ls-remote` against the same ref from outside GitHub Actions resolves
+correctly. Unified all three occurrences to the file-based lookup the third one
+already used (read `.github/ghcommon-ref.txt`, falling back to a hardcoded SHA)
+and added that file, pointing at the current commit — this sidesteps live ref
+resolution entirely rather than depending on whatever caching layer produced the
+bad SHA.
+
 #### `reusable-release.yml` — ghcommon workflow-scripts checkout pointed at the pre-migration `jdfalk/ghcommon` repo
 
 All three "Checkout ghcommon workflow scripts" steps hardcoded


### PR DESCRIPTION
## Summary
- Two of the three "Determine ghcommon workflow ref" steps parsed `GITHUB_WORKFLOW_REF`, which in a reusable-workflow context yields the *calling* repo's own ref (`refs/heads/main`), not one specific to `falkcorp/github-common`.
- That ref name happens to also be valid in `github-common`, but `actions/checkout`'s resolution of it hit a reproducible GitHub Actions-side bug: it consistently returned a commit SHA (`eb6e7b30bbad14fcee5ac1ae96b9bf92a1460fd1`) that doesn't exist in either repo — confirmed via the GitHub API (422 on both repos) and via a direct `git ls-remote` from outside Actions, which resolves the same ref correctly to the real HEAD. Failed identically on 2 separate runs/reruns.
- Unified all three occurrences to the file-based lookup the third one already used (read `.github/ghcommon-ref.txt`, fall back to a hardcoded SHA if absent) and added that file, pointing at the current commit. This sidesteps live ref resolution for this checkout entirely.

## Test plan
- [ ] Merge, bump the pin in `audiobook-organizer`, and confirm "Create GitHub Release" succeeds without the promisor-remote fetch error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT