### PR TITLE
fix(release): bump gha-release-go pin to fix same-commit tag ambiguity

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.2
+# version: 2.14.3
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -355,7 +355,7 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
       - name: Build Go
-        uses: falkcorp/gha-release-go@17e3c8358687a19006d96caade7178c5c9b41874 # v2.0.0
+        uses: falkcorp/gha-release-go@e6b2fa793ea1f43d6baee44c77c6047b5abe7f15 # v2.0.1 (GORELEASER_CURRENT_TAG pin)
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+#### `reusable-release.yml` — bump `gha-release-go` pin to fix same-commit tag ambiguity
+
+Bumped to `gha-release-go@e6b2fa7` (v2.0.1), which pins `GORELEASER_CURRENT_TAG`
+explicitly instead of letting GoReleaser infer it via `git describe`. Without
+this, a concurrent release process (e.g. a `Prerelease on Merge` run triggered
+by a routine PR merge) tagging the same commit could cause `describe` to resolve
+to the wrong tag, making GoReleaser build under that tag and collide with the
+other release's already-uploaded assets (`422 already_exists`). Reproduced 3
+times in a row on `falkcorp/audiobook-organizer`.
+
 #### Remaining `jdfalk/ghcommon` references across 9 workflow files, post org migration to `falkcorp/github-common`
 
 `reusable-release.yml`'s pre-migration repo-ref bug (fixed above) turned out to


### PR DESCRIPTION
## Summary
- Bumps to `gha-release-go@e6b2fa7` (v2.0.1, [falkcorp/gha-release-go#7](https://github.com/falkcorp/gha-release-go/pull/7)), which pins `GORELEASER_CURRENT_TAG` explicitly instead of letting GoReleaser infer it via `git describe`.
- Fixes a real, reproduced (3x) bug: when a concurrent release process (e.g. a `Prerelease on Merge` run triggered by a routine PR merge) tags the same commit, `describe` was ambiguous and could resolve to the wrong tag, causing GoReleaser to build under that tag and collide with the other release's already-uploaded assets (`422 already_exists`).

## Test plan
- [ ] Merge, bump the pin in `audiobook-organizer`, and confirm a Production Release dispatch completes cleanly even when a concurrent prerelease tags the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT