### PR TITLE
fix(release): guard cleanup step from deleting the just-created stable release

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.3
+# version: 2.14.4
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -692,8 +692,11 @@ jobs:
             echo "$keep_list" | sed 's/^/  - /'
           fi
 
-          # List drafts + prereleases. The stable release we just cut has
-          # isDraft=false and isPrerelease=false, so it's excluded here.
+          # List drafts + prereleases. In principle the stable release we just
+          # cut has isDraft=false/isPrerelease=false and is excluded here, but
+          # a stale list read (or a leftover draft placeholder reused under
+          # the same tag by the release-creation step) can still surface it —
+          # so the loop below also hard-guards on the tag string itself.
           releases=$(gh release list --limit 500 --json tagName,isDraft,isPrerelease \
             --jq '.[] | select(.isDraft or .isPrerelease) | .tagName')
 
@@ -706,6 +709,15 @@ jobs:
           kept=0
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
+
+            # Never delete the release we just cut, regardless of what
+            # isDraft/isPrerelease report for it above.
+            if [ "$tag" = "$STABLE_VERSION" ]; then
+              echo "Skipping just-created stable release: $tag"
+              kept=$((kept + 1))
+              continue
+            fi
+
             # base = version stripped of leading v and any -rc/-alpha/-beta suffix
             base="${tag#v}"
             base="${base%%-*}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixed
 
+#### `reusable-release.yml` — cleanup step no longer deletes the stable release it just created
+
+The "Clean up superseded drafts and prereleases" step queries
+`gh release list --json tagName,isDraft,isPrerelease` and deletes anything
+matching drafts/prereleases with a version `<=` the new stable version, under
+the assumption that the just-cut stable release (draft=false, prerelease=false)
+is naturally excluded from that set. Observed on `falkcorp/audiobook-organizer`
+v0.217.6: the just-created stable release's own tag showed up in that "drafts or
+prereleases" set anyway (most likely a stale list read, or a leftover rolling
+"next stable" draft placeholder reused under the same tag by the
+release-creation step) and was deleted seconds after
+`softprops/action-gh-release` logged "🎉 Release ready" — leaving the release
+API 404ing on the tag it had just published. Added an explicit guard that skips
+any tag exactly matching `$STABLE_VERSION`, independent of what
+`isDraft`/`isPrerelease` report for it.
+
 #### `reusable-release.yml` — bump `gha-release-go` pin to fix same-commit tag ambiguity
 
 Bumped to `gha-release-go@e6b2fa7` (v2.0.1), which pins `GORELEASER_CURRENT_TAG`


### PR DESCRIPTION
## Summary

- The "Clean up superseded drafts and prereleases" step in `reusable-release.yml` deletes anything `gh release list` reports as a draft/prerelease with a version `<=` the new stable version, assuming the just-cut stable release (`isDraft=false`, `isPrerelease=false`) is naturally excluded.
- Observed on `falkcorp/audiobook-organizer` v0.217.6: the just-created release's own tag showed up in that "drafts or prereleases" set anyway and was deleted seconds after `softprops/action-gh-release` logged "🎉 Release ready" — job log: `Deleting superseded release: v0.217.6 (base 0.217.6 <= 0.217.6)`. `gh release view v0.217.6` 404s afterward despite the same job reporting full success (binaries + Docker + changelog uploaded).
- Added an explicit guard that skips any tag exactly matching `$STABLE_VERSION`, independent of what `isDraft`/`isPrerelease` report for it — robust regardless of whether the root cause is a stale `gh release list` read or a leftover rolling-draft placeholder reused under the same tag.

## Test plan

- [x] Verified the guard logic offline against the real tag set from the `v0.217.6` failure (`v0.217.6-rc.2/.1`, `v0.217.5-rc.1`, `v0.217.4-rc.1`, `v0.217.3-rc.7`, plus `v0.217.6` itself) — confirms the stable tag is now skipped and the 5 RCs are still correctly kept.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly.
- [ ] CI on this PR (yamllint/actionlint/etc.)
- [ ] End-to-end: bump the pin in `audiobook-organizer`, dispatch Production Release, confirm the resulting stable release persists (`gh release view <tag>` succeeds with `draft:false`, `prerelease:false`).