### PR TITLE
fix(workflows): drop submodules: recursive from ghcommon sparse-checkout steps

### DIFF
--- a/.github/workflows/commit-override-handler.yml
+++ b/.github/workflows/commit-override-handler.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/commit-override-handler.yml
-# version: 1.3.4
+# version: 1.3.5
 # guid: 7a8b9c0d-1e2f-3456-789a-bcdef0123456
 
 # ⚠️  DO NOT EDIT DIRECTLY - This file is managed in ghcommon repository
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: .ghcommon

--- a/.github/workflows/reusable-advanced-cache.yml
+++ b/.github/workflows/reusable-advanced-cache.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-advanced-cache.yml
-# version: 1.1.4
+# version: 1.1.5
 # guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 
 name: Reusable Advanced Caching
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           sparse-checkout: |

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-ci.yml
-# version: 1.12.4
+# version: 1.12.5
 # guid: reusable-ci-2025-09-24-core-workflow
 
 name: Reusable CI Workflow
@@ -434,7 +434,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -525,7 +525,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -591,7 +591,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -686,7 +686,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -823,7 +823,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts

--- a/.github/workflows/reusable-maintenance.yml
+++ b/.github/workflows/reusable-maintenance.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-maintenance.yml
-# version: 1.0.5
+# version: 1.0.6
 # guid: reusable-maintenance-2025-09-24-core-workflow
 
 name: Reusable Maintenance Workflow
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           sparse-checkout: |

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.4
+# version: 2.14.5
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -483,7 +483,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -795,7 +795,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           path: ghcommon-workflow-scripts
@@ -966,7 +966,7 @@ jobs:
       - name: Checkout ghcommon workflow scripts
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          # do not add submodules: recursive here — sparse-checkout can't lazy-fetch .gitmodules, causing a promisor-fetch 400
           repository: falkcorp/github-common
           ref: ${{ steps.ghcommon-ref.outputs.ref }}
           sparse-checkout: |


### PR DESCRIPTION
## Summary
- The narrow "Checkout ghcommon workflow scripts" step (used in 5 reusable workflows to pull just a script subpath via `sparse-checkout`) also had `submodules: recursive` set. Sparse-checkout auto-enables a partial (`blob:none`) clone, and with submodules enabled, git tries to lazily fetch the `.gitmodules` blob from the promisor remote to resolve them — GitHub's git-http backend rejects that fetch with a duplicate-Authorization-header 400, aborting the step.
- The failure surfaced as what looked like a "stale SHA" checkout error (`eb6e7b30bb...`), but that hash is a blob (`.gitmodules` content), not a commit — nothing to do with the checked-out ref itself.
- None of these steps ever needed submodule content (excluded by the sparse pattern anyway), so removing the flag changes no behavior except eliminating the failing round-trip.
- Confirmed this reproduces identically from a *caller* repo (`audiobook-organizer`'s `reusable-ci.yml` `ci-summary` job hit the same blob/400 failure), ruling out the "double-checkout of github-common in one job" theory from earlier debugging.
- Added a short comment at each of the 11 call sites (5 files) explaining why `submodules: recursive` must not be re-added there, since these workflow files are known to get swept by blanket "add submodules everywhere" changes.

## Test plan
- [x] YAML validity checked for all 5 changed files (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Pre-commit hooks (yamllint, prettier, etc.) pass
- [ ] CI green on this PR
- [ ] Re-run `commit-override-handler.yml` / `reusable-ci.yml`'s CI Summary job on a downstream repo post-merge to confirm the promisor-fetch 400 no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiDS2SAWX5JaxQKAeAoLYV