### PR TITLE
fix(workflows): bump gha-docs-generator pin to relative-path fix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/documentation.yml
-# version: 1.1.1
+# version: 1.1.2
 # guid: docs-automation-workflow-2025
 
 name: Documentation
@@ -33,7 +33,7 @@ jobs:
         with:
           submodules: recursive
       - name: Generate helper documentation
-        uses: falkcorp/gha-docs-generator@8207d873d6300212e4d22b97aa22e9b1114f64a7 # v1.1.3
+        uses: falkcorp/gha-docs-generator@ecaefb4b0110d11683bc7ad0b6b968209aeca4af # v1.1.6-rc.4
         with:
           source-dir: .github/workflows/scripts
           workflows-dir: .github/workflows


### PR DESCRIPTION
## Summary
- Follow-up to falkcorp/gha-docs-generator#22, which fixed a relative/absolute path bug that crashed the "Build Documentation" workflow's doc-generation step on every run (surfacing as `'.github/workflows/auto-module-tagging.yml' is not in the subpath of ...`).
- This org pins action references to commit SHAs, not tags, so merging #22 alone did nothing for this repo until the pin here is bumped.
- Bumped `falkcorp/gha-docs-generator@8207d873...` (v1.1.3) → `@ecaefb4b0110d11683bc7ad0b6b968209aeca4af` (v1.1.6-rc.4, the commit containing the fix — no stable tag has been cut since).

## Test plan
- [x] YAML validity + pre-commit hooks pass
- [ ] CI green, in particular the "Build Documentation" job no longer crashes with the subpath error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiDS2SAWX5JaxQKAeAoLYV