### PR TITLE
feat(changelog): deliver fragment system org-wide via reusable workflows

### DIFF
--- a/.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh
+++ b/.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh
@@ -219,7 +219,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- scriv-insert-here -->
 EOF
   fi
   ;;
@@ -244,7 +244,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- scriv-insert-here -->
 EOF
   fi
   ;;

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -784,6 +784,67 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Require a changelog fragment on PRs for repos that use the changelog.d/
+  # fragment system. Opt-in by presence: the job self-skips (passes) for every
+  # repo without changelog.d/scriv.ini. See changelog.d/README.md in
+  # falkcorp/github-common.
+  changelog-fragment-check:
+    name: Changelog Fragment Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Require a changelog fragment
+        run: |
+          set -euo pipefail
+
+          # Opt-in by presence: repos without the fragment system pass immediately.
+          if [ ! -f changelog.d/scriv.ini ]; then
+            echo "::notice::changelog.d/scriv.ini not present — changelog fragments not enabled here."
+            exit 0
+          fi
+
+          if [ "${SKIP_LABEL}" = "true" ]; then
+            echo "::notice::'skip-changelog' label present — skipping."
+            exit 0
+          fi
+          case "${PR_TITLE}" in
+            *"[skip changelog]"*)
+              echo "::notice::'[skip changelog]' in PR title — skipping."
+              exit 0
+              ;;
+          esac
+
+          git fetch --no-tags origin "${BASE_REF}"
+
+          # Files added on this branch that are real fragments: Markdown under
+          # changelog.d/, excluding the docs/config/template scaffolding.
+          added="$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" \
+            | { grep -E '^changelog\.d/.*\.md$' || true; } \
+            | { grep -vE '^changelog\.d/(README\.md$|templates/)' || true; })"
+
+          if [ -n "${added}" ]; then
+            echo "Found changelog fragment(s):"
+            echo "${added}"
+            exit 0
+          fi
+
+          echo "::error::No changelog fragment under changelog.d/. Run 'scriv create'"
+          echo "(see changelog.d/README.md), or add the 'skip-changelog' label or"
+          echo "'[skip changelog]' to the PR title if no changelog entry is needed."
+          exit 1
+
   # Summary job
   ci-summary:
     name: CI Summary

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -92,6 +92,11 @@ on:
         required: false
         type: string
         default: ''
+      changelog-collect:
+        description: "Assemble CHANGELOG.md from changelog.d/ fragments (scriv) on stable releases. Empty auto-enables when changelog.d/scriv.ini exists; 'false' disables."
+        required: false
+        type: string
+        default: ''
     outputs:
       release-created:
         description: 'Whether a release was created'
@@ -596,6 +601,74 @@ jobs:
           files: |
             ./artifacts/**/*
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Assemble CHANGELOG.md from changelog.d/ fragments (scriv) and commit it
+      # back to the default branch. Opt-in by presence: only runs when the
+      # calling repo has changelog.d/scriv.ini (see changelog.d/README.md in
+      # falkcorp/github-common). No-op for every repo without that file.
+      - name: Collect changelog fragments
+        if: >-
+          github.event_name != 'pull_request' &&
+          inputs.changelog-collect != 'false' &&
+          needs.detect-languages.outputs.auto-prerelease != 'true' &&
+          hashFiles('changelog.d/scriv.ini') != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CHANGELOG_PAT: ${{ secrets.JF_CI_GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VERSION:-}" ]; then
+            echo "::warning::No version resolved; skipping changelog collect."
+            exit 0
+          fi
+
+          # Defensive: scriv needs a CHANGELOG.md carrying the insert marker.
+          # Skip cleanly if the repo has scriv.ini but no marker-bearing changelog.
+          if [ ! -f CHANGELOG.md ] || ! grep -q 'scriv-insert-here' CHANGELOG.md; then
+            echo "::warning::changelog.d/scriv.ini present but CHANGELOG.md lacks the scriv-insert-here marker; skipping collect."
+            exit 0
+          fi
+
+          # Only real fragments count — README.md, templates/ and scriv.ini don't.
+          if ! find changelog.d -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "::notice::No changelog fragments to collect for ${VERSION}."
+            exit 0
+          fi
+
+          python3 -m pip install --quiet scriv
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          python3 -m scriv collect --version "${VERSION}"
+
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "::notice::scriv produced no CHANGELOG.md changes."
+            exit 0
+          fi
+
+          git add -A CHANGELOG.md changelog.d
+          # [skip ci] stops this changelog commit from retriggering release CI.
+          git commit -m "docs(changelog): collect fragments for ${VERSION} [skip ci]"
+
+          # Prefer the PAT (passes branch protection); fall back to the workflow
+          # token. Push to an explicit authenticated URL so we don't depend on the
+          # checkout's persisted credentials.
+          TOKEN="${CHANGELOG_PAT:-$GITHUB_TOKEN}"
+          REMOTE="https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          n=0
+          until git push "${REMOTE}" "HEAD:${DEFAULT_BRANCH}" || [ "$n" -ge 4 ]; do
+            n=$((n + 1))
+            echo "Retry $n/4 for changelog push..."
+            sleep $((2 ** n))
+            git pull --rebase "${REMOTE}" "${DEFAULT_BRANCH}"
+          done
+          [ "$n" -lt 4 ] || { echo "::error::Failed to push CHANGELOG.md"; exit 1; }
+          echo "CHANGELOG.md updated for ${VERSION}"
 
       - name: Create or update draft full release
         if: needs.detect-languages.outputs.auto-prerelease == 'true' && github.event_name != 'pull_request'

--- a/scripts/intelligent_sync_to_repos.py
+++ b/scripts/intelligent_sync_to_repos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # file: scripts/intelligent_sync_to_repos.py
-# version: 1.3.0
+# version: 1.4.0
 # guid: a1b2c3d4-e5f6-7890-1234-567890abcdef
 
 """Intelligent sync script that understands the new modular .github structure.
@@ -90,6 +90,13 @@ MANAGED_FILES = {
     ".github/prompts/pull-request.prompt.md",
     ".github/prompts/security-review.prompt.md",
     ".github/prompts/test-generation.prompt.md",
+    # Changelog fragments (scriv) scaffolding. CHANGELOG.md is assembled from
+    # these fragments by the reusable release workflow and enforced by the
+    # reusable CI workflow; both are opt-in by presence of changelog.d/scriv.ini.
+    # CHANGELOG.md itself is repo-specific and intentionally NOT synced.
+    "changelog.d/scriv.ini",
+    "changelog.d/templates/new_fragment.md.j2",
+    "changelog.d/README.md",
     # Core documentation (versioned) - DEPRECATED, moved to instructions/
     # These are kept for backward compatibility but should be removed eventually
     ".github/test-generation.md",


### PR DESCRIPTION
## Summary

Makes the scriv changelog-fragments system (introduced for `github-common`
itself in #323) available to **every** org repo, by baking the behavior into the
**reusable workflows** that downstream repos already `uses:` — rather than
pushing per-repo workflow files (which the file-sync can't do reliably; GitHub
App permissions block workflow pushes).

**Everything here is opt-in by presence of `changelog.d/scriv.ini`.** Merging
this PR is an immediate **no-op** for every repo that hasn't adopted the system;
a repo activates only once it has the `changelog.d/` scaffolding + a
`CHANGELOG.md` carrying the `<!-- scriv-insert-here -->` marker.

Depends on / pairs with **#323** (which adds the scaffolding to `github-common`
and retires its two standalone changelog workflows). Ordering: **#323 merges
first**, then this. If this merges first it simply stays dormant until #323
lands — there is no double-collect window either way.

## Issues Addressed

### feat(changelog): bake collect + fragment-check into reusable workflows

**Description:** `reusable-release.yml` gains a `Collect changelog fragments`
step that, on stable releases, runs `scriv collect` and commits the assembled
`CHANGELOG.md` back to the default branch with `[skip ci]` (loop-safe). It is
guarded on `changelog.d/scriv.ini` presence, a marker-bearing `CHANGELOG.md`,
and non-prerelease; pushes via `JF_CI_GH_PAT` (falling back to the workflow
token). `reusable-ci.yml` gains a `changelog-fragment-check` job that requires a
fragment on PRs, self-skips when the repo hasn't adopted the system, and honors
a `skip-changelog` label / `[skip changelog]` PR-title escape hatch.
Distribution of the static scaffolding rides the existing **targeted**
`intelligent_sync_to_repos.py` (not the blanket `sync-repo-setup.py`, to respect
a pilot-first rollout), and new `library`/`cli` repos are born scriv-ready via
the bootstrap skeleton.

**Files Modified:**

- [`.github/workflows/reusable-release.yml`](./.github/workflows/reusable-release.yml) - Opt-in `scriv collect` step (commit `[skip ci]`, PAT push, marker + prerelease guards) + `changelog-collect` input
- [`.github/workflows/reusable-ci.yml`](./.github/workflows/reusable-ci.yml) - Opt-in `changelog-fragment-check` job (self-skips without `changelog.d/scriv.ini`; label/title escape hatch)
- [`scripts/intelligent_sync_to_repos.py`](./scripts/intelligent_sync_to_repos.py) - Add `changelog.d/` scaffolding (scriv.ini, template, README) to `MANAGED_FILES`; `CHANGELOG.md` intentionally not synced
- [`.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh`](./.claude/skills/bootstrap-repo/scripts/bootstrap_repo.sh) - `library`/`cli` `CHANGELOG.md` skeleton now carries the `scriv-insert-here` marker

## Testing

- `actionlint` (v1.7.1) — clean on both changed workflows (expressions +
  embedded shell).
- `yamllint` (repo config) — clean, no new warnings.
- `python -m py_compile` + `ruff` (repo config) — clean on the sync script.
- `bash -n` — clean on `bootstrap_repo.sh`.
- Opt-in no-op verified by construction: both behaviors gate on
  `hashFiles('changelog.d/scriv.ini')` / an in-step presence check, which is
  empty/false for repos without the scaffolding.
- End-to-end `scriv collect` round-trip was validated in #323.

## Breaking Changes

None for repos without `changelog.d/`. For adopting repos: `CHANGELOG.md` is
assembled at release time and enforced on PRs.

## Additional Notes

Deliberately did **not** wire the scaffolding into the blanket
`sync-repo-setup.py` (which auto-discovers and syncs to all owned repos) — that
would activate the fragment-check across every repo on the next sync, contrary to
the pilot-first plan. Rollout to specific repos goes through the targeted
`intelligent_sync_to_repos.py` (explicit `--repos`). The dormant
`@semantic-release/changelog` toolkit is left untouched (it must stay off so
scriv is the single owner of `CHANGELOG.md`).

Next: pilot on 2–3 repos (e.g. `falkcorp/audiobook-organizer` + a `jdfalk`
repo), then expand.

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made
- [x] Changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] New and existing unit tests pass locally with the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW)_