### PR TITLE
fix(ci): make the Code Quality super-linter advisory, not a PR blocker

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/pr-automation.yml
-# version: 4.5.6
+# version: 4.5.7
 # guid: a7b8c9d0-e1f2-3456-a789-0123456789bc
 # NOTE: This file should be updated in ghcommon repository first, then copied to other repositories.
 # To update: Edit in https://github.com/falkcorp/github-common/.github/workflows/pr-automation.yml then copy to other repos
@@ -122,6 +122,11 @@ jobs:
 
       - name: Run Super Linter with Auto-Fix
         id: run-super-linter
+        # Advisory auto-fix pass: it applies and commits fixable issues and
+        # reports the rest in the job summary (via steps.run-super-linter.outcome),
+        # but a lint finding must not hard-fail the PR. Real linting is enforced
+        # separately by reusable-ci.yml. Without this the job blocked every PR.
+        continue-on-error: true
         uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `Code Quality Check` job in `pr-automation.yml` runs super-linter in
**auto-fix** mode (every `FIX_*` enabled, auto-commit) — it's meant to fix what
it can and report the rest. But the `Run Super Linter` step had no
`continue-on-error`, so any lint finding made the step (and the whole job)
**fail and block the PR**. That's the check that's been red across the org with
effectively empty output.

## Fix

Add `continue-on-error: true` to the super-linter step:

- Fixable issues are still auto-applied and committed.
- The real lint status is still reported in the job summary via
  `steps.run-super-linter.outcome`.
- A lint finding no longer hard-fails the PR.
- Actual lint enforcement still happens in `reusable-ci.yml` (separate job).

Confirmed the job's own logic supports this: the `Check for auto-fixes` step has
no `if: always()`, so today it's skipped whenever super-linter fails — proving
the super-linter step itself is what fails the job. With `continue-on-error` the
step's conclusion is success, so auto-fix detection/commit runs and the job
passes.

**Files Modified:**

- [`.github/workflows/pr-automation.yml`](./.github/workflows/pr-automation.yml) - `continue-on-error: true` on the super-linter step

## Testing

- `yamllint` (repo config) and `actionlint` (v1.7.1) — clean.

## Additional Notes

`pr-automation.yml` is centrally managed and copied to downstream repos, so this
fix should be propagated to them as well (their copies carry the same blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW)_