### PR TITLE
fix(todo): make TODO.md header upkeep best-effort in the assembler

### DIFF
--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -3075,7 +3075,7 @@
     "path": "scripts/assemble_todo.py",
     "guid": "af7ef324-6c69-411e-b1a9-98c9ba2b31e3",
     "title": "assemble todo",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "header_path": "scripts/assemble_todo.py",
     "path_mismatch": false
   },

--- a/changelog.d/20260719-assembler-optional-headers.md
+++ b/changelog.d/20260719-assembler-optional-headers.md
@@ -1,0 +1,14 @@
+### Fixed
+
+#### `assemble_todo.py` no longer aborts when the output file lacks a header line
+
+`bump_header` raised and failed the whole collect if `TODO.md` had no
+`version:` or `last-edited:` line. That is fine in this repo, where both are
+always present, but wrong across a fleet: several adopting repos have a
+`version:` line and no `last-edited:` (transcoderr, for one), so their first
+scheduled collect would have failed with nothing to do about it.
+
+Header upkeep is now best-effort — each line is refreshed only if present, and a
+missing one is a warning rather than an error. Adding tasks is the job; header
+maintenance must never be the reason a scheduled collect fails. Genuinely unsafe
+conditions (a missing insert marker, a missing output file) still raise.

--- a/scripts/assemble_todo.py
+++ b/scripts/assemble_todo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # file: scripts/assemble_todo.py
-# version: 1.0.0
+# version: 1.1.0
 # guid: af7ef324-6c69-411e-b1a9-98c9ba2b31e3
 # last-edited: 2026-07-19
 
@@ -97,9 +97,15 @@ def fragment_body(path: Path) -> str:
 def bump_header(text: str, today: str) -> str:
     """Bump the output file's patch version and refresh ``last-edited``.
 
-    Every file this repo touches must carry an updated header, and the collect
-    commit is a real modification of TODO.md — so the assembler maintains the
-    header itself rather than leaving CI to complain about a stale one.
+    The collect commit is a real modification of the output file, so the
+    assembler maintains its header rather than leaving CI to complain about a
+    stale one.
+
+    Best-effort by design: each header line is updated only if present. Adding
+    tasks is the job, and header upkeep must never be the reason a scheduled
+    collect fails — repos that adopt this system carry heterogeneous headers,
+    and plenty have a `version:` line but no `last-edited:` (or neither). A
+    missing line is reported as a warning and the collect proceeds.
     """
 
     def _bump(match: re.Match[str]) -> str:
@@ -112,17 +118,13 @@ def bump_header(text: str, today: str) -> str:
 
     text, count = VERSION_HEADER.subn(_bump, text, count=1)
     if not count:
-        raise AssemblyError(
-            "Output file has no '<!-- version: X.Y.Z -->' header."
-        )
+        print("warning: no '<!-- version: X.Y.Z -->' header to bump.")
 
     text, count = LAST_EDITED_HEADER.subn(
         lambda m: f"{m.group(1)}{today}{m.group(3)}", text, count=1
     )
     if not count:
-        raise AssemblyError(
-            "Output file has no '<!-- last-edited: ... -->' header."
-        )
+        print("warning: no '<!-- last-edited: ... -->' header to refresh.")
     return text
 
 


### PR DESCRIPTION
## Summary

Found while validating the fan-out against a **real** adopting repo before
opening 13 PRs — `bump_header` raised `AssemblyError` and failed the entire
collect when the output file had no `version:` or `last-edited:` header line.

github-common's `TODO.md` has both, so this never surfaced in #328. But it is
wrong across the fleet: `falkcorp/transcoderr`'s `TODO.md` has a `version:` line
and **no** `last-edited:` at all, so its very first scheduled collect would have
failed with nothing the repo could do about it.

Header upkeep is now **best-effort** — each line is refreshed only if present,
and a missing one prints a warning instead of raising. Adding tasks is the job;
header maintenance must never be why a scheduled collect fails. Conditions that
are genuinely unsafe to guess at (no insert marker, no output file) still raise
as before.

## Testing

Both paths verified:

- **github-common** (`version:` + `last-edited:`) — unchanged behavior, bumps
  `2.3.5 → 2.3.6` and refreshes the date.
- **transcoderr clone** (`version:` only) — previously died with
  `error: Output file has no '<!-- last-edited: ... -->' header.`; now warns,
  bumps `0.6.0 → 0.6.1`, inserts the task, and deletes the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2