### PR TITLE
fix(ci): don't request the pip cache when no Python manifest exists

### DIFF
--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -979,7 +979,7 @@
     "path": ".github/workflows/reusable-ci.yml",
     "guid": "reusable-ci-2025-09-24-core-workflow",
     "title": "Reusable CI Workflow",
-    "version": "1.12.5",
+    "version": "1.13.0",
     "header_path": ".github/workflows/reusable-ci.yml",
     "path_mismatch": false
   },

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-ci.yml
-# version: 1.12.5
+# version: 1.13.0
 # guid: reusable-ci-2025-09-24-core-workflow
 
 name: Reusable CI Workflow
@@ -506,11 +506,30 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      # actions/setup-python fails the job outright when `cache: pip` is set but
+      # the repo has no requirements.txt / pyproject.toml ("No file in ... matched
+      # to [**/requirements.txt or **/pyproject.toml]"). A repo can legitimately
+      # have Python sources and no dependency manifest — a single stdlib-only
+      # script is enough to activate this job — so detect the manifest and only
+      # ask for the pip cache when there is something to cache.
+      - name: Detect Python dependency manifest
+        id: py-manifest
+        run: |
+          set -euo pipefail
+          if find . -path ./.git -prune -o \
+               \( -name 'requirements*.txt' -o -name 'pyproject.toml' \) -print \
+               | grep -q .; then
+            echo "cache=pip" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Python dependency manifest found; skipping the pip cache."
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+          cache: ${{ steps.py-manifest.outputs.cache }}
 
       - name: Get ghcommon workflow ref
         id: ghcommon-ref

--- a/changelog.d/20260719-python-ci-no-manifest.md
+++ b/changelog.d/20260719-python-ci-no-manifest.md
@@ -1,0 +1,16 @@
+### Fixed
+
+#### `reusable-ci.yml` — Python CI no longer fails in repos without a dependency manifest
+
+The Python job set `cache: pip` unconditionally, and `actions/setup-python`
+fails the job outright when it finds no `requirements.txt` or `pyproject.toml`:
+`No file in ... matched to [**/requirements.txt or **/pyproject.toml]`.
+
+Any repository that acquired its first Python file while having no dependency
+manifest hit this — a single stdlib-only script is enough to activate the job.
+It surfaced when `scripts/assemble_todo.py` was added to
+`falkcorp/cockroach-rollout-agent`, a repo with no Python at all, turning a
+previously green CI red.
+
+The manifest is now detected first and the pip cache is requested only when
+there is something to cache; otherwise setup runs uncached and emits a notice.


### PR DESCRIPTION
## Summary

`reusable-ci.yml`'s Python job set `cache: pip` unconditionally.
`actions/setup-python` **fails the job outright** when it finds no
`requirements.txt` or `pyproject.toml`:

```
No file in ... matched to [**/requirements.txt or **/pyproject.toml],
make sure you have checked out the target repository
```

So any repository that acquires its first Python file while having no dependency
manifest goes red — a single stdlib-only script is enough to activate the job.

Found during the TODO fan-out: adding `scripts/assemble_todo.py` to
`falkcorp/cockroach-rollout-agent` — a repo with **zero** Python files and no
manifest, whose CI on `main` was green — turned it red. The fan-out surfaced the
bug, but it was latent for any repo in this situation.

## Fix

Detect the manifest first, and request the pip cache only when there is
something to cache. Otherwise `setup-python` runs uncached and emits a notice.

## Testing

- Detection verified both ways: a tree containing `requirements.txt` resolves to
  `cache=pip`; an empty tree resolves to no cache.
- `actionlint` passes on the modified workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2