### PR TITLE
chore(sync): add the todo.d scaffolding to MANAGED_FILES

### DIFF
--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -3211,7 +3211,7 @@
     "path": "scripts/intelligent_sync_to_repos.py",
     "guid": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
     "title": "intelligent sync to repos",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "header_path": "scripts/intelligent_sync_to_repos.py",
     "path_mismatch": false
   },

--- a/changelog.d/20260719-managed-files-todo.md
+++ b/changelog.d/20260719-managed-files-todo.md
@@ -1,0 +1,11 @@
+### Changed
+
+#### `intelligent_sync_to_repos.py` now syncs the `todo.d/` scaffolding
+
+The TODO fragment system's shared files — `todo.d/todo.ini`, its template and
+README, `scripts/assemble_todo.py`, and `.github/workflows/todo-collect.yml` —
+are added to `MANAGED_FILES`, so future syncs keep adopting repositories current
+the same way they already do for `changelog.d/`.
+
+`TODO.md` itself is deliberately **not** synced: it is repo-specific and carries
+each repository's own `<!-- todo-insert-here -->` marker and curated sections.

--- a/scripts/intelligent_sync_to_repos.py
+++ b/scripts/intelligent_sync_to_repos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # file: scripts/intelligent_sync_to_repos.py
-# version: 1.4.0
+# version: 1.5.0
 # guid: a1b2c3d4-e5f6-7890-1234-567890abcdef
 
 """Intelligent sync script that understands the new modular .github structure.
@@ -97,6 +97,15 @@ MANAGED_FILES = {
     "changelog.d/scriv.ini",
     "changelog.d/templates/new_fragment.md.j2",
     "changelog.d/README.md",
+    # TODO fragment scaffolding. TODO.md is assembled from these fragments by
+    # scripts/assemble_todo.py, run by .github/workflows/todo-collect.yml;
+    # opt-in by presence of todo.d/todo.ini. TODO.md itself is repo-specific
+    # and intentionally NOT synced — it carries each repo's own insert marker.
+    "todo.d/todo.ini",
+    "todo.d/templates/new_fragment.md",
+    "todo.d/README.md",
+    "scripts/assemble_todo.py",
+    ".github/workflows/todo-collect.yml",
     # Core documentation (versioned) - DEPRECATED, moved to instructions/
     # These are kept for backward compatibility but should be removed eventually
     ".github/test-generation.md",
@@ -139,8 +148,12 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Intelligently sync .github structure to target repos."
     )
-    parser.add_argument("--repos", required=True, help="Comma-separated list of target repos")
-    parser.add_argument("--branch", required=True, help="Branch name to push to")
+    parser.add_argument(
+        "--repos", required=True, help="Comma-separated list of target repos"
+    )
+    parser.add_argument(
+        "--branch", required=True, help="Branch name to push to"
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -154,13 +167,17 @@ def run(cmd: list[str], cwd=None, check=True, dry_run=False):
     if dry_run:
         logging.info("  [DRY RUN] Command not executed")
         return None
-    result = subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)
+    result = subprocess.run(
+        cmd, cwd=cwd, check=check, capture_output=True, text=True
+    )
     if result.stdout:
         logging.info(result.stdout)
     if result.stderr:
         logging.error(result.stderr)
     if check and result.returncode != 0:
-        raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, result.stdout, result.stderr
+        )
     return result
 
 
@@ -170,7 +187,9 @@ def create_vscode_copilot_symlinks(repo_dir: str, dry_run: bool):
     github_instructions_dir = os.path.join(repo_dir, ".github", "instructions")
 
     if not os.path.exists(github_instructions_dir):
-        logging.info("  [SKIP] .github/instructions/ not found, skipping VS Code symlinks")
+        logging.info(
+            "  [SKIP] .github/instructions/ not found, skipping VS Code symlinks"
+        )
         return
 
     if dry_run:
@@ -195,7 +214,9 @@ def create_vscode_copilot_symlinks(repo_dir: str, dry_run: bool):
             )
 
 
-def sync_to_repo(repo: str, branch: str, gh_token: str, summary: list[str], dry_run: bool):
+def sync_to_repo(
+    repo: str, branch: str, gh_token: str, summary: list[str], dry_run: bool
+):
     logging.info(f"\n=== Syncing to {repo} ===")
 
     if dry_run:
@@ -217,9 +238,13 @@ def sync_to_repo(repo: str, branch: str, gh_token: str, summary: list[str], dry_
         # Show VS Code symlinks that would be created
         logging.info("    VS Code Copilot symlinks:")
         for file in MANAGED_FILES:
-            if file.startswith(".github/instructions/") and file.endswith(".instructions.md"):
+            if file.startswith(".github/instructions/") and file.endswith(
+                ".instructions.md"
+            ):
                 basename = os.path.basename(file)
-                logging.info(f"      CREATE: .vscode/copilot/{basename} -> ../../{file}")
+                logging.info(
+                    f"      CREATE: .vscode/copilot/{basename} -> ../../{file}"
+                )
 
         summary.append(
             f"[DRY RUN] {repo}: Would sync {len(MANAGED_FILES)} files and clean up {len(OLD_FILES_TO_REMOVE)} old files"
@@ -339,7 +364,9 @@ the new VS Code Copilot customization features."""
 
                 # Create or update PR after successful sync
                 if not dry_run:
-                    create_or_update_pr(repo, branch, summary)  # PR creation handled separately
+                    create_or_update_pr(
+                        repo, branch, summary
+                    )  # PR creation handled separately
             except subprocess.CalledProcessError as e:
                 summary.append(f"[FAIL] {repo}: Push failed - {e!s}")
         else:
@@ -446,9 +473,13 @@ See [jdfalk/ghcommon](https://github.com/jdfalk/ghcommon) for the source of trut
                 logging.warning(
                     f"Could not create PR for {repo} after {max_retries} attempts: {e.stderr}"
                 )
-                summary.append(f"[WARN] {repo}: Could not create PR - {e.stderr.strip()}")
+                summary.append(
+                    f"[WARN] {repo}: Could not create PR - {e.stderr.strip()}"
+                )
             else:
-                logging.info(f"  PR creation failed, waiting {retry_delay}s before retry...")
+                logging.info(
+                    f"  PR creation failed, waiting {retry_delay}s before retry..."
+                )
 
 
 def main():

--- a/scripts/intelligent_sync_to_repos.py
+++ b/scripts/intelligent_sync_to_repos.py
@@ -145,6 +145,7 @@ REPO_SPECIFIC_FILES = {
 
 
 def parse_args():
+    """Parse the command-line arguments for a sync run."""
     parser = argparse.ArgumentParser(
         description="Intelligently sync .github structure to target repos."
     )
@@ -163,6 +164,7 @@ def parse_args():
 
 
 def run(cmd: list[str], cwd=None, check=True, dry_run=False):
+    """Run a command, logging it first and honoring dry-run mode."""
     logging.info(f"$ {' '.join(cmd)}")
     if dry_run:
         logging.info("  [DRY RUN] Command not executed")
@@ -182,7 +184,7 @@ def run(cmd: list[str], cwd=None, check=True, dry_run=False):
 
 
 def create_vscode_copilot_symlinks(repo_dir: str, dry_run: bool):
-    """Create VS Code Copilot symlinks in .vscode/copilot/ pointing to .github/instructions/"""
+    """Create .vscode/copilot symlinks pointing at .github/instructions."""
     vscode_copilot_dir = os.path.join(repo_dir, ".vscode", "copilot")
     github_instructions_dir = os.path.join(repo_dir, ".github", "instructions")
 
@@ -217,6 +219,7 @@ def create_vscode_copilot_symlinks(repo_dir: str, dry_run: bool):
 def sync_to_repo(
     repo: str, branch: str, gh_token: str, summary: list[str], dry_run: bool
 ):
+    """Sync the managed files into one repo and open or update its PR."""
     logging.info(f"\n=== Syncing to {repo} ===")
 
     if dry_run:
@@ -483,6 +486,7 @@ See [jdfalk/ghcommon](https://github.com/jdfalk/ghcommon) for the source of trut
 
 
 def main():
+    """Sync every requested repo and write a run summary."""
     args = parse_args()
 
     if not args.dry_run:
@@ -491,7 +495,7 @@ def main():
             print("GH_TOKEN environment variable is required.", file=sys.stderr)
             sys.exit(1)
     else:
-        gh_token = "dummy-for-dry-run"
+        gh_token = "dummy-for-dry-run"  # noqa: S105 - placeholder, never used to authenticate
 
     repos = [r.strip() for r in args.repos.split(",") if r.strip()]
     branch = args.branch


### PR DESCRIPTION
## Summary

The TODO fragment system's shared files now propagate through the normal sync
path, exactly as `changelog.d/` already does:

- `todo.d/todo.ini`
- `todo.d/templates/new_fragment.md`
- `todo.d/README.md`
- `scripts/assemble_todo.py`
- `.github/workflows/todo-collect.yml`

`TODO.md` itself is deliberately **excluded** — it is repo-specific, carrying
each repository's own `<!-- todo-insert-here -->` marker and curated sections,
and syncing it would overwrite them. Same reasoning that keeps `CHANGELOG.md`
out of the list.

This is the follow-up flagged in #328 and completes the fan-out: the 13 adoption
PRs deliver the files once, and this keeps them current afterwards.

## Note on diff size

Beyond the 10-line `MANAGED_FILES` addition, the pre-commit ruff hook normalized
some pre-existing long lines in this file to 80 columns. That is required rather
than cosmetic: CI lints the files a commit changes, so touching this file brings
it under the root `ruff.toml` (80 col) formatting gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2