### PR TITLE
fix(ci): refresh the stale ghcommon script pin across reusable workflows

### DIFF
--- a/.github/workflows/commit-override-handler.yml
+++ b/.github/workflows/commit-override-handler.yml
@@ -71,7 +71,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-advanced-cache.yml
+++ b/.github/workflows/reusable-advanced-cache.yml
@@ -58,7 +58,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
+            echo "ref=e73b80106099118143806b0ce58e0a73cbcfb27c" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ghcommon workflow scripts

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -427,7 +427,14 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            # Fallback pin for repos with no .github/ghcommon-ref.txt. This MUST be
+            # kept current with this workflow: the workflow is consumed at @main but
+            # the scripts come from this SHA, so a stale pin means main invokes
+            # subcommands the pinned ci_workflow.py does not define. The previous pin
+            # (e04c222, 2026-03-28) predated the rust-* commands added in 767acd4
+            # (2026-05-27), so every repo without the ref file failed Rust CI with
+            # "Unknown command: rust-build".
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
@@ -537,7 +544,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
@@ -603,7 +610,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
@@ -698,7 +705,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
@@ -896,7 +903,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             ref="$(cat .github/ghcommon-ref.txt)"
           else
-            ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
+            ref="e73b80106099118143806b0ce58e0a73cbcfb27c"
           fi
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-maintenance.yml
+++ b/.github/workflows/reusable-maintenance.yml
@@ -50,7 +50,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
+            echo "ref=e73b80106099118143806b0ce58e0a73cbcfb27c" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ghcommon workflow scripts

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -482,7 +482,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
+            echo "ref=e73b80106099118143806b0ce58e0a73cbcfb27c" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ghcommon workflow scripts
@@ -862,7 +862,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
+            echo "ref=e73b80106099118143806b0ce58e0a73cbcfb27c" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ghcommon workflow scripts
@@ -1033,7 +1033,7 @@ jobs:
           if [ -f .github/ghcommon-ref.txt ]; then
             echo "ref=$(cat .github/ghcommon-ref.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "ref=e04c222a0366d5801d3b02bb76519f19ba1fa440" >> "$GITHUB_OUTPUT"
+            echo "ref=e73b80106099118143806b0ce58e0a73cbcfb27c" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout ghcommon workflow scripts

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -278,7 +278,7 @@ jobs:
         with:
           submodules: recursive
           repository: falkcorp/github-common
-          ref: e04c222a0366d5801d3b02bb76519f19ba1fa440 # v1.10.3+
+          ref: e73b80106099118143806b0ce58e0a73cbcfb27c # v1.10.3+
           path: .ghcommon
           sparse-checkout: |
             .github/scripts

--- a/changelog.d/20260720-stale-ghcommon-script-pin.md
+++ b/changelog.d/20260720-stale-ghcommon-script-pin.md
@@ -1,0 +1,18 @@
+### Fixed
+
+#### Reusable workflows no longer fetch four-month-stale helper scripts
+
+Every reusable workflow that checks out this repo's own
+`.github/workflows/scripts` fell back to a hardcoded
+`e04c222a0366d5801d3b02bb76519f19ba1fa440` when the calling repo had no
+`.github/ghcommon-ref.txt`. That commit is from **2026-03-28**.
+
+Callers consume the workflows at `@main`, so current workflow logic was invoking
+helper subcommands that the pinned script predates. Rust CI failed outright with
+`##[error]Unknown command: rust-build` in every repo without the ref file — the
+`rust-*` commands were added in 767acd4 on **2026-05-27**, two months after the
+pin.
+
+All 11 occurrences across 6 workflows now point at current `main`, and the
+fallback carries a comment explaining that it must be kept in step with the
+workflows it ships alongside.


### PR DESCRIPTION
## Summary

Every reusable workflow that checks out **this repo's own**
`.github/workflows/scripts` falls back to a hardcoded SHA when the calling repo
has no `.github/ghcommon-ref.txt`:

```
ref="e04c222a0366d5801d3b02bb76519f19ba1fa440"
```

**That commit is from 2026-03-28.** Callers consume the workflows at `@main`, so
`main`'s workflow logic has been invoking helper subcommands that the four-month-
old pinned script doesn't define:

```
##[error]Unknown command: rust-build
```

The `rust-*` subcommands were added in `767acd4` on **2026-05-27** — two months
*after* the pin. So Rust CI fails outright in every repo without the ref file.

Surfaced by `falkcorp/cockroach-rollout-agent`, whose Rust CI activated for the
first time during the TODO fan-out (its `Cargo.lock` changed). Verified locally
that the repo itself is fine — `cargo clippy --all-targets -- -D warnings`,
`cargo build --release` and `cargo test` all pass; the failure was purely this
version skew.

## Change

All **11 occurrences across 6 workflows** now point at current `main`:

| Workflow | Pins |
|---|---|
| `reusable-ci.yml` | 5 |
| `reusable-release.yml` | 3 |
| `reusable-advanced-cache.yml` | 1 |
| `reusable-maintenance.yml` | 1 |
| `reusable-security.yml` | 1 |
| `commit-override-handler.yml` | 1 |

The primary fallback now carries a comment explaining that it **must be kept in
step with the workflows shipped beside it** — a stale pin here means `main`
calls into scripts that predate it.

> Worth considering separately: this fallback is inherently a footgun, since the
> workflow and the scripts live in the same repo but are versioned independently.
> Deriving the ref from the running workflow would remove the failure mode
> entirely.

## Testing

`actionlint` clean on all six changed workflows — no structural errors, and the
only output is pre-existing shellcheck warnings in untouched `run:` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2