### PR TITLE
fix(ci): run cargo build/test inline instead of a missing action command

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-ci.yml
-# version: 1.13.0
+# version: 1.14.0
 # guid: reusable-ci-2025-09-24-core-workflow
 
 name: Reusable CI Workflow
@@ -652,16 +652,16 @@ jobs:
         with:
           command: rust-clippy
 
+      # Build and test run inline rather than through gha-ci-workflow-helpers:
+      # the action never implemented the rust-build / rust-test commands (only
+      # rust-format and rust-clippy exist, in every release through v1.1.7), so
+      # invoking them failed every Rust CI run with "Unknown command: rust-build".
       - name: Build Rust project
-        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
-        with:
-          command: rust-build
+        run: cargo build --release
 
       - name: Test Rust project
         if: ${{ !inputs.skip-tests }}
-        uses: falkcorp/gha-ci-workflow-helpers@c8b87fae92ee0a0458e47b970ed892310323aa58 # v1.1.4
-        with:
-          command: rust-test
+        run: cargo test --release
 
   # Setup npm cache for frontend using advanced cache strategy
   frontend-npm-cache:

--- a/changelog.d/20260720-rust-build-inline.md
+++ b/changelog.d/20260720-rust-build-inline.md
@@ -1,0 +1,14 @@
+### Fixed
+
+#### Rust CI no longer fails with "Unknown command: rust-build"
+
+The Rust job invoked `gha-ci-workflow-helpers` with `command: rust-build` and
+`command: rust-test`, but that action never implemented either command — only
+`rust-format` and `rust-clippy` exist, in every release through v1.1.7. So every
+repository whose Rust CI actually ran failed at the build step with
+`Unknown command: rust-build`.
+
+The build and test steps now run `cargo build --release` / `cargo test --release`
+inline. Format and clippy still go through the action, which does support them.
+Surfaced by falkcorp/cockroach-rollout-agent, whose Rust CI activated for the
+first time during the TODO fan-out.


### PR DESCRIPTION
## Summary

The Rust job in `reusable-ci.yml` invokes `gha-ci-workflow-helpers` with
`command: rust-build` and `command: rust-test` — but **that action never
implemented either command**. Only `rust-format` and `rust-clippy` exist, in
every release through v1.1.7. So every repository whose Rust CI actually runs
dies at the build step:

```
##[error]Unknown command: rust-build
```

`reusable-ci.yml` was migrated to call action commands that were never added to
the action. This is fleet-wide — any repo with active Rust CI hits it.

## Change

`Build Rust project` and `Test Rust project` now run `cargo build --release` /
`cargo test --release` inline. `Format` and `Lint` keep using the action, which
does support `rust-format` / `rust-clippy`.

Kept minimal deliberately — no `--locked` (would fail any repo with a drifted
lock) and no `--all-targets` (would force-build benches that some repos gate on
nightly).

## Context

Surfaced by `falkcorp/cockroach-rollout-agent`, whose Rust CI activated for the
first time during the TODO fan-out (its `Cargo.lock` changed, and Rust CI was
`skipped` on its main before). Verified the crate itself is clean:
`cargo clippy --all-targets -- -D warnings`, `cargo build --release`, and
`cargo test` all pass locally — the failure was purely this missing-command bug.

Note this is distinct from #333 (the stale ghcommon-**script** pin): these Rust
commands run through the external **action**, not the checked-out scripts, so the
pin refresh didn't touch them.

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2