### PR TITLE
docs(agents): document changelog/TODO fragment system in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 2.4.0 -->
+<!-- version: 2.5.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
-<!-- last-edited: 2026-06-13 -->
+<!-- last-edited: 2026-07-21 -->
 
 # github-common — Additional Context
 
@@ -27,3 +27,19 @@ Reusable GitHub Actions workflows, scripts, and multi-repo automation. Language:
 - `scripts/intelligent_sync_to_repos.py` — propagates changes to target repos; use `--dry-run` first
 - `scripts/workflow-debugger.py` — analyzes workflow failures; outputs to `workflow-debug-output/fix-tasks/`
 - All commits must use conventional commit format: `type(scope): description`
+
+## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+
+**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
+`TODO.md` inbox.** Both files are assembled from per-change fragments so that
+parallel PRs never collide on them.
+
+- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
+  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
+  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
+  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
+- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
+  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
+  section. `scripts/assemble_todo.py` folds fragments in daily. This is
+  **add-only**: checking a task off or removing it is a normal direct edit of
+  `TODO.md`.

--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -59,7 +59,7 @@
     "path": ".github/copilot-instructions.md",
     "guid": "4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a",
     "title": "github-common \u2014 Additional Context",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "header_path": ".github/copilot-instructions.md",
     "path_mismatch": false
   },
@@ -91,7 +91,7 @@
     "path": ".github/instructions/copilot-instructions.md",
     "guid": "4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a",
     "title": "github-common \u2014 Additional Context",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "header_path": ".github/copilot-instructions.md",
     "path_mismatch": true
   },
@@ -979,7 +979,7 @@
     "path": ".github/workflows/reusable-ci.yml",
     "guid": "reusable-ci-2025-09-24-core-workflow",
     "title": "Reusable CI Workflow",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "header_path": ".github/workflows/reusable-ci.yml",
     "path_mismatch": false
   },

--- a/changelog.d/document-fragment-system-for-agents.md
+++ b/changelog.d/document-fragment-system-for-agents.md
@@ -1,0 +1,8 @@
+### Changed
+
+#### Document the changelog/TODO fragment system for AI agents
+
+`CLAUDE.md` and `.github/copilot-instructions.md` now instruct AI agents to use
+the `changelog.d/` and `todo.d/` fragment systems instead of editing
+`CHANGELOG.md` or the `TODO.md` inbox directly, preventing parallel-PR
+collisions on those files.


### PR DESCRIPTION
## Summary

The `changelog.d/` and `todo.d/` fragment systems were documented in `CLAUDE.md` but **not** in `.github/copilot-instructions.md` — the detailed instruction file that `CLAUDE.md` explicitly points agents to. An agent following the pointer would find nothing about fragments.

This adds a **"Changelog & TODO — Use the Fragment System (MANDATORY)"** section to `.github/copilot-instructions.md`, closing that gap in the source of truth. Phase 1 of propagating the rule; focused doc PRs to the 12 adopting repos follow.

## Changes
- `.github/copilot-instructions.md` — append the fragment-system section; bump `version` 2.4.0 → 2.5.0
- `changelog.d/` — fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)