### PR TITLE
fix(release): repoint 6 orphaned gha-release-* action pins crashing Dependabot

### DIFF
--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -1003,7 +1003,7 @@
     "path": ".github/workflows/reusable-release.yml",
     "guid": "7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e",
     "title": "Reusable Release Coordinator",
-    "version": "2.14.5",
+    "version": "2.14.6",
     "header_path": ".github/workflows/reusable-release.yml",
     "path_mismatch": false
   },

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/reusable-release.yml
-# version: 2.14.5
+# version: 2.14.6
 # guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 name: Reusable Release Coordinator
@@ -360,7 +360,7 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
       - name: Build Go
-        uses: falkcorp/gha-release-go@e6b2fa793ea1f43d6baee44c77c6047b5abe7f15 # v2.0.1 (GORELEASER_CURRENT_TAG pin)
+        uses: falkcorp/gha-release-go@cf4aea678c05f80410cd468683f38bd782f7915e # v1.0.3 (GORELEASER_CURRENT_TAG pin)
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
@@ -385,7 +385,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Python
-        uses: falkcorp/gha-release-python@f3105cab8ecca34051c16c989cc809b19ae5a297 # v2.0.0
+        uses: falkcorp/gha-release-python@a6acf4ec1ced26d355ab06032a014c415bb5be13 # v1.0.3
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
 
@@ -404,7 +404,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Rust
-        uses: falkcorp/gha-release-rust@fcee6b67fc61c0da24d890d850793ccae981ccbf # v2.0.0
+        uses: falkcorp/gha-release-rust@9cdb217e2a5caa4855b6568df8416f2014cee01b # v1.0.3
         with:
           protobuf-artifacts: ${{ needs.detect-languages.outputs.protobuf-needed }}
           release-version: ${{ needs.detect-languages.outputs.release-tag }}
@@ -424,7 +424,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Frontend
-        uses: falkcorp/gha-release-frontend@d2a4a8364559606e0f5ac04ef87963a660eab8ac # v2.0.0
+        uses: falkcorp/gha-release-frontend@731cf92c81c31e1372edc7612c055b160a704c1f # v1.0.3
 
   # Docker Build
   build-docker:
@@ -441,7 +441,7 @@ jobs:
         with:
           submodules: recursive
       - name: Build Docker
-        uses: falkcorp/gha-release-docker@5438b1e9389357ebe4142d23944ee89f0afd9d11 # v2.0.0
+        uses: falkcorp/gha-release-docker@f277535984a419a3c68d9336234ed429accea5b2 # v1.0.3
         with:
           registry: ${{ needs.detect-languages.outputs.registry }}
           image-name: ${{ needs.detect-languages.outputs.image-name }}
@@ -526,7 +526,7 @@ jobs:
           path: ./artifacts
       - name: Package and organize release artifacts
         id: package-artifacts
-        uses: falkcorp/gha-package-assets@c1dc41c8fb6800606eee2714da4d7b807d55ecc4 # v1.2.0
+        uses: falkcorp/gha-package-assets@a55b9a19b91fc5882d571849ad44c2e460688f7b # v1.1.5
         with:
           artifacts-dir: ./artifacts
 

--- a/changelog.d/fix-orphaned-action-pins.md
+++ b/changelog.d/fix-orphaned-action-pins.md
@@ -1,0 +1,10 @@
+### Fixed
+
+#### Repoint 6 orphaned `falkcorp/gha-release-*` action pins that crashed Dependabot
+
+`reusable-release.yml` pinned six first-party actions (gha-release-python/docker/go/rust/frontend,
+gha-package-assets) to commit SHAs labelled with `v2.0.x`/`v1.2.0` tags that were never published.
+Those SHAs are unreachable from any tag, so Dependabot's `github_actions` updater crashed with
+`no such commit …` — and because the ecosystem is part of the `multi-ecosystem-group`, the crash
+blocked all grouped version-update PRs (none created since 2026-06-04). Repinned each to its latest
+real release (v1.0.3 / v1.1.5).


### PR DESCRIPTION
## Root cause (this is why Dependabot stopped opening PRs)

Diagnosed from the **Dependabot dynamic run logs** (visible in Actions as `dynamic` events — thanks to that pointer). Job `job_1471642895` (`github_actions in /. - Update`) crashed:

```
ERROR Error processing falkcorp/gha-release-python (HelperSubprocessFailed)
error: no such commit f3105cab8ecca34051c16c989cc809b19ae5a297
  ...GithubActions...find_container_branch / latest_commit_for_pinned_ref
```

`reusable-release.yml` pinned six first-party actions to commit SHAs labelled `# v2.0.x` / `# v1.2.0` — **tags that were never published** (all 404). Those commits are unreachable from any tag, so Dependabot's `github_actions` updater crashes trying to resolve them. Because `github_actions` is part of the `multi-ecosystem-group: dependencies`, that single crash **blocks the entire grouped version-update PR** — which is why **zero** version-update PRs have been created since 2026-06-04 (#289).

GitHub Actions itself tolerates the orphaned SHAs (it fetches the exact commit), so releases kept working — only Dependabot choked, silently.

## Fix

Repoint each to its **latest real release**:

| Action | Was (phantom) | Now |
|---|---|---|
| gha-release-python | `# v2.0.0` | `a6acf4ec` `# v1.0.3` |
| gha-release-docker | `# v2.0.0` | `f2775359` `# v1.0.3` |
| gha-release-go | `# v2.0.1` | `cf4aea67` `# v1.0.3` |
| gha-release-rust | `# v2.0.0` | `9cdb217e` `# v1.0.3` |
| gha-release-frontend | `# v2.0.0` | `731cf92c` `# v1.0.3` |
| gha-package-assets | `# v1.2.0` | `a55b9a19` `# v1.1.5` |

Not a downgrade — those v2 tags never existed; v1.0.3 / v1.1.5 are each action's current latest release (chronologically newer than the orphaned SHAs).

The remaining stale-but-valid pins (protobuf, detect-languages, docs-generator) point to real tags and will be bumped by Dependabot itself once this unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)