### PR TITLE
fix(deps): force brace-expansion >=5.0.7 via npm override

### DIFF
--- a/changelog.d/fix-brace-expansion-override.md
+++ b/changelog.d/fix-brace-expansion-override.md
@@ -1,0 +1,8 @@
+### Security
+
+#### Force `brace-expansion` >= 5.0.7 via npm override (last open Dependabot alert)
+
+Added a `brace-expansion` npm `overrides` entry (matching the existing lodash/js-yaml/fast-uri
+pattern) to force the transitive dev dependency to a patched 5.0.7. It was pinned at 5.0.6 under
+`@typescript-eslint/typescript-estree`; Dependabot's security-updater could not bump it
+("update_not_possible: downgrades_dependencies"). `npm` now reports 0 vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -759,29 +759,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -954,19 +931,24 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/callsites": {
@@ -1069,12 +1051,6 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "overrides": {
     "lodash": "^4.18.0",
     "js-yaml": "^4.2.0",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "brace-expansion": "^5.0.7"
   }
 }


### PR DESCRIPTION
## Summary

Closes the **last open Dependabot alert** on this repo. `brace-expansion@5.0.6` (GHSA, ReDoS) was pulled in transitively by `@typescript-eslint/typescript-estree` (dev scope). Dependabot's security-updater refused it (`update_not_possible: downgrades_dependencies`), so this uses the repo's established `overrides` pattern (already applied for lodash/js-yaml/fast-uri).

- `package.json` — add `"brace-expansion": "^5.0.7"` override
- `package-lock.json` — regenerated; both tree instances (1.1.16 + 5.0.6) dedupe to a single 5.0.7
- `npm install` reports **0 vulnerabilities**

🤖 Generated with [Claude Code](https://claude.com/claude-code)