### PR TITLE
chore(dependabot): extend pip coverage to /scripts and /scripts/copilot-firewall

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Dependabot Configuration
-# version: 1.0.0
+# version: 1.1.0
 # guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 version: 2
@@ -42,7 +42,10 @@ updates:
 
   # Pip
   - package-ecosystem: pip
-    directory: /
+    directories:
+      - /
+      - /scripts
+      - /scripts/copilot-firewall
     patterns: ['*']
     multi-ecosystem-group: dependencies
     labels:

--- a/.github/guid-index.json
+++ b/.github/guid-index.json
@@ -67,7 +67,7 @@
     "path": ".github/dependabot.yml",
     "guid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "title": "dependabot",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "header_path": "",
     "path_mismatch": false
   },

--- a/changelog.d/dependabot-pip-dir-coverage.md
+++ b/changelog.d/dependabot-pip-dir-coverage.md
@@ -1,0 +1,7 @@
+### Changed
+
+#### Extend Dependabot pip coverage to `/scripts` and `/scripts/copilot-firewall`
+
+The pip `dependabot.yml` entry only scanned `/`, leaving `scripts/requirements-notifications.txt`
+and `scripts/copilot-firewall/requirements.txt` without version/security-update PRs. Switched
+`directory: /` to a `directories` list covering all three so every tracked pip manifest is updated.


### PR DESCRIPTION
## Summary

The pip `dependabot.yml` entry only scanned `/`, so two tracked manifests got no update PRs:
- `scripts/requirements-notifications.txt`
- `scripts/copilot-firewall/requirements.txt` (its Pygments alert had no path to a fix)

Switched `directory: /` → a `directories` list covering all three. Also forces a fresh Dependabot re-registration, which confirms the `github_actions` updater no longer crashes after #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)