### PR TITLE
chore: update burndown-runner-image to ob-1680f86

### DIFF
--- a/.github/workflows/reusable-burndown.yml
+++ b/.github/workflows/reusable-burndown.yml
@@ -14,7 +14,7 @@
 # Exits early if none found. Otherwise: triage → dispatch (matrix) → aggregate.
 #
 # The burndown binary is pre-baked into
-# ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2 at /usr/local/bin/burndown.
+# ghcr.io/falkcorp/burndown-runner-image:ob-1680f86 at /usr/local/bin/burndown.
 # Config is driven entirely by environment variables — no config.yaml needed.
 
 name: Burndown (reusable)
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-1680f86
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-1680f86
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-1680f86
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}
@@ -484,7 +484,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-1680f86
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.JF_CI_GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-triage-poll.yml
+++ b/.github/workflows/reusable-triage-poll.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/falkcorp/burndown-runner-image:ob-7d131c2
+      image: ghcr.io/falkcorp/burndown-runner-image:ob-1680f86
     steps:
       - name: Materialize App key
         env:


### PR DESCRIPTION
Automatic update from burndown-runner-image build.

New image tag: `ghcr.io/falkcorp/burndown-runner-image:ob-1680f86`
Contains overnight-burndown@1680f86349b7bac504f7fb62788cb5b4c0f37542

**Lines changed:** 14
**Auto-merged:** true

---
🤖 Generated by the Build image workflow